### PR TITLE
Shw -> develop / 플레이어 스폰 오류 수정 및 동기화

### DIFF
--- a/Assets/Develop/SHW/Scripts/PlayerController.cs
+++ b/Assets/Develop/SHW/Scripts/PlayerController.cs
@@ -83,9 +83,18 @@ public class PlayerController : MonoBehaviourPun, IExplosionInteractable
     {
         // Debug.Log("¹°¹æ¿ï¿¡ °¤Èû!");
 
-        _status.isBubble = true;
-        bubble.SetActive(true);
+        //_status.isBubble = true;
+        //bubble.SetActive(true);
+
+        photonView.RPC("BubbledRPC", RpcTarget.All);
 
         return true;
+    }
+
+    [PunRPC]
+    public void BubbledRPC()
+    {
+        _status.isBubble = true;
+        bubble.SetActive(true);
     }
 }

--- a/Assets/Develop/SHW/Scripts/TestScene.cs
+++ b/Assets/Develop/SHW/Scripts/TestScene.cs
@@ -17,34 +17,34 @@ public class TestScene : MonoBehaviourPunCallbacks
         // 닉네임도 일단 대충 랜덤 부여
         PhotonNetwork.LocalPlayer.NickName = $"Player {Random.Range(1000, 10000)}";
         // 시작하자마자 접속할거니깐
-        PhotonNetwork.ConnectUsingSettings();
+        // PhotonNetwork.ConnectUsingSettings();
 
-        Player player;
-        // player.ActorNumber = 1;
-    }
-
-    public override void OnPlayerEnteredRoom(Player newPlayer)
-    {
-        playerNum = newPlayer.ActorNumber;
-        // spawner.PlayerSpawn(playerNum);
-    }
-
-    // 그냥 서버말고 마스터 서버에 접속시키자
-    public override void OnConnectedToMaster()
-    {
-        RoomOptions options = new RoomOptions();
-        options.MaxPlayers = 8;
-        options.IsVisible = false;
-
-        // 룸 이름, 옵션, 로비타입을 적어주자
-        // 로비는 건너 뛸거니 TypedLobby.Default 로 설정 (null로 두면 오류)
-        PhotonNetwork.JoinOrCreateRoom(RoomName, options, TypedLobby.Default);
-    }
-
-    public override void OnJoinedRoom()
-    {
         StartCoroutine(StartDelayRoutine());
     }
+
+    //public override void OnPlayerEnteredRoom(Player newPlayer)
+    //{
+    //    playerNum = newPlayer.ActorNumber;
+    //    // spawner.PlayerSpawn(playerNum);
+    //}
+
+    // 그냥 서버말고 마스터 서버에 접속시키자
+    //public override void OnConnectedToMaster()
+    //{
+    //    RoomOptions options = new RoomOptions();
+    //    options.MaxPlayers = 8;
+    //    options.IsVisible = false;
+
+    //    // 룸 이름, 옵션, 로비타입을 적어주자
+    //    // 로비는 건너 뛸거니 TypedLobby.Default 로 설정 (null로 두면 오류)
+    //    PhotonNetwork.JoinOrCreateRoom(RoomName, options, TypedLobby.Default);
+    //}
+
+    //public override void OnJoinedRoom()
+    //{
+    //    // StartCoroutine(StartDelayRoutine());
+    //    TestGameStart();
+    //}
 
     // 들어오자마자 시작하면 오류가 있을 수 있으니 네트워크 정리를 해줄 시간 벌어주기
     IEnumerator StartDelayRoutine()

--- a/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
+++ b/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
@@ -42,6 +42,7 @@ MonoBehaviour:
   - PlaceBomb
   - RPC_Chat
   - OnPickedUp_RPC
+  - BubbledRPC
   DisableAutoOpenWizard: 1
   ShowSettings: 1
   DevRegionSetOnce: 1


### PR DESCRIPTION
# 구체적 목록
* 로비에서 게임 씬으로 넘어와 테스트 할 경우 스폰이 되지 않던 부분 스타트시 바로 생성하도록 설정하였습니다.
* 플레이어가 물방울에 갇혔을 때 동기화 되지 않던 부분 수정했습니다.