### PR TITLE
KMS->Develop/[fix] 게임 씬 Enterable오브젝트 프리펩 충돌체 수정.

### DIFF
--- a/Assets/Develop/KMS/Prefabs/MapPrefabs/Forest07.prefab
+++ b/Assets/Develop/KMS/Prefabs/MapPrefabs/Forest07.prefab
@@ -726,6 +726,39 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 1, y: 1.0867765, z: 1}
   m_Center: {x: 0, y: 0.00039952993, z: 0.0010752678}
+--- !u!1 &1828072466455825903
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1828072466455825902}
+  m_Layer: 0
+  m_Name: Tile_x(4)_z(10)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1828072466455825902
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1828072466455825903}
+  m_LocalRotation: {x: -0, y: 1, z: -0, w: -0.00000004371139}
+  m_LocalPosition: {x: 4, y: 0, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1828072467153212993}
+  - {fileID: 1828072468523452669}
+  m_Father: {fileID: 1828072466884861296}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072466456228178
 GameObject:
   m_ObjectHideFlags: 0
@@ -780,12 +813,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1828072466457896474}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: -1, z: 0}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1828072466895680839}
+  m_Father: {fileID: 1828072466745728139}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072466464591812
@@ -946,9 +979,8 @@ GameObject:
   - component: {fileID: 1828072466466845273}
   - component: {fileID: 1828072466466845254}
   - component: {fileID: 1828072466466845255}
-  - component: {fileID: 5292812745763790072}
   m_Layer: 0
-  m_Name: Tile_x(14)_z(5)
+  m_Name: pipe_X_LOD0
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -961,15 +993,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1828072466466845253}
-  m_LocalRotation: {x: -0, y: 1, z: -0, w: -0.00000004371139}
-  m_LocalPosition: {x: 14, y: 1, z: -5}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1828072466647081775}
-  - {fileID: 1828072467032029537}
-  m_Father: {fileID: 1828072466535608645}
-  m_RootOrder: 13
+  m_Father: {fileID: 1828072466599096580}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &1828072466466845275
 MeshFilter:
@@ -1053,7 +1084,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59a25a69e624bd24ca2d80c531be02f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _innerObjs: []
+  shrinkRate: 0.1
 --- !u!114 &1828072466466845255
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1076,19 +1107,6 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
---- !u!65 &5292812745763790072
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1828072466466845253}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 1, y: 0.953548, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072466469086081
 GameObject:
   m_ObjectHideFlags: 0
@@ -2253,10 +2271,10 @@ Transform:
   - {fileID: 1828072468266326407}
   - {fileID: 1828072468068710143}
   - {fileID: 1828072468471288328}
-  - {fileID: 1828072468403328176}
+  - {fileID: 1828072466679693289}
   - {fileID: 1828072466885812092}
   - {fileID: 1828072467261945406}
-  - {fileID: 1828072466466845252}
+  - {fileID: 1828072466599096580}
   - {fileID: 1828072467051846467}
   - {fileID: 1828072466517897714}
   m_Father: {fileID: 1828072467680842488}
@@ -2592,12 +2610,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1828072466563840268}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: -1, z: 0}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1828072467601158192}
+  m_Father: {fileID: 1828072466616357472}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072466564619530
@@ -3144,6 +3162,39 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
+--- !u!1 &1828072466599096581
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1828072466599096580}
+  m_Layer: 0
+  m_Name: Tile_x(14)_z(5)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1828072466599096580
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1828072466599096581}
+  m_LocalRotation: {x: -0, y: 1, z: -0, w: -0.00000004371139}
+  m_LocalPosition: {x: 14, y: 0, z: -5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1828072466466845252}
+  - {fileID: 1828072467032029537}
+  m_Father: {fileID: 1828072466535608645}
+  m_RootOrder: 13
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072466616168211
 GameObject:
   m_ObjectHideFlags: 0
@@ -3288,6 +3339,39 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
+--- !u!1 &1828072466616357473
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1828072466616357472}
+  m_Layer: 0
+  m_Name: Tile_x(7)_z(6)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1828072466616357472
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1828072466616357473}
+  m_LocalRotation: {x: -0, y: 1, z: -0, w: -0.00000004371139}
+  m_LocalPosition: {x: 7, y: 0, z: -6}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1828072467601158192}
+  - {fileID: 1828072466563840271}
+  m_Father: {fileID: 1828072467343233353}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072466619956608
 GameObject:
   m_ObjectHideFlags: 0
@@ -3903,6 +3987,39 @@ Transform:
   - {fileID: 1828072467081844972}
   m_Father: {fileID: 1828072466774537543}
   m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1828072466679692822
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1828072466679693289}
+  m_Layer: 0
+  m_Name: Tile_x(11)_z(5)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1828072466679693289
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1828072466679692822}
+  m_LocalRotation: {x: -0, y: 1, z: -0, w: -0.00000004371139}
+  m_LocalPosition: {x: 11, y: 0, z: -5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1828072468403328176}
+  - {fileID: 1828072468276407433}
+  m_Father: {fileID: 1828072466535608645}
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072466680645821
 GameObject:
@@ -5486,6 +5603,39 @@ Transform:
   m_Father: {fileID: 1828072467680842488}
   m_RootOrder: 12
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1828072466745728136
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1828072466745728139}
+  m_Layer: 0
+  m_Name: Tile_x(3)_z(4)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1828072466745728139
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1828072466745728136}
+  m_LocalRotation: {x: -0, y: 1, z: -0, w: -0.00000004371139}
+  m_LocalPosition: {x: 3, y: 0, z: -4}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1828072466895680839}
+  - {fileID: 1828072466457896477}
+  m_Father: {fileID: 1828072467312348390}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072466748584482
 GameObject:
   m_ObjectHideFlags: 0
@@ -6063,6 +6213,39 @@ Transform:
   - {fileID: 1828072466650911004}
   m_Father: {fileID: 1828072468552108882}
   m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1828072466789206718
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1828072466789206705}
+  m_Layer: 0
+  m_Name: Tile_x(10)_z(2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1828072466789206705
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1828072466789206718}
+  m_LocalRotation: {x: -0, y: 1, z: -0, w: -0.00000004371139}
+  m_LocalPosition: {x: 10, y: 0, z: -2}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1828072468133137351}
+  - {fileID: 1828072467433378497}
+  m_Father: {fileID: 1828072468552108882}
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072466795274927
 GameObject:
@@ -7584,16 +7767,16 @@ Transform:
   - {fileID: 1828072466480312874}
   - {fileID: 1828072467666372076}
   - {fileID: 1828072466917088504}
-  - {fileID: 1828072467153212993}
+  - {fileID: 1828072466455825902}
   - {fileID: 1828072467097792783}
   - {fileID: 1828072467751162725}
   - {fileID: 1828072467190787372}
-  - {fileID: 1828072467427259937}
+  - {fileID: 1828072467395161644}
   - {fileID: 1828072466773949940}
   - {fileID: 1828072468459210376}
   - {fileID: 1828072467593079229}
   - {fileID: 1828072467391626548}
-  - {fileID: 1828072468133465298}
+  - {fileID: 1828072468224380250}
   - {fileID: 1828072466512633531}
   - {fileID: 1828072466831034477}
   m_Father: {fileID: 1828072467680842488}
@@ -7646,9 +7829,8 @@ GameObject:
   - component: {fileID: 1828072466895680856}
   - component: {fileID: 1828072466895680857}
   - component: {fileID: 1828072466895680838}
-  - component: {fileID: 5686626070234464567}
   m_Layer: 0
-  m_Name: Tile_x(3)_z(4)
+  m_Name: pipe_X_LOD0
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -7661,15 +7843,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1828072466895680836}
-  m_LocalRotation: {x: -0, y: 1, z: -0, w: -0.00000004371139}
-  m_LocalPosition: {x: 3, y: 1, z: -4}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1828072466643041551}
-  - {fileID: 1828072466457896477}
-  m_Father: {fileID: 1828072467312348390}
-  m_RootOrder: 3
+  m_Father: {fileID: 1828072466745728139}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &1828072466895680858
 MeshFilter:
@@ -7753,7 +7934,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59a25a69e624bd24ca2d80c531be02f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _innerObjs: []
+  shrinkRate: 0.1
 --- !u!114 &1828072466895680838
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -7776,19 +7957,6 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
---- !u!65 &5686626070234464567
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1828072466895680836}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 1, y: 0.953548, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072466896088262
 GameObject:
   m_ObjectHideFlags: 0
@@ -10400,12 +10568,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1828072467032029550}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: -1, z: 0}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1828072466466845252}
+  m_Father: {fileID: 1828072466599096580}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072467033491191
@@ -12597,9 +12765,8 @@ GameObject:
   - component: {fileID: 1828072467153212994}
   - component: {fileID: 1828072467153212995}
   - component: {fileID: 1828072467153212992}
-  - component: {fileID: 55918244286903656}
   m_Layer: 0
-  m_Name: Tile_x(4)_z(10)
+  m_Name: pipe_X_LOD0
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -12612,15 +12779,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1828072467153213006}
-  m_LocalRotation: {x: -0, y: 1, z: -0, w: -0.00000004371139}
-  m_LocalPosition: {x: 4, y: 1, z: -10}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1828072467522755429}
-  - {fileID: 1828072468523452669}
-  m_Father: {fileID: 1828072466884861296}
-  m_RootOrder: 3
+  m_Father: {fileID: 1828072466455825902}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &1828072467153212996
 MeshFilter:
@@ -12704,7 +12870,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59a25a69e624bd24ca2d80c531be02f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _innerObjs: []
+  shrinkRate: 0.1
 --- !u!114 &1828072467153212992
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -12727,19 +12893,6 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
---- !u!65 &55918244286903656
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1828072467153213006}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 1, y: 0.953548, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072467160703214
 GameObject:
   m_ObjectHideFlags: 0
@@ -14996,6 +15149,39 @@ Transform:
   m_Father: {fileID: 1828072467315392315}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1828072467238474970
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1828072467238474973}
+  m_Layer: 0
+  m_Name: Tile_x(3)_z(6)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1828072467238474973
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1828072467238474970}
+  m_LocalRotation: {x: -0, y: 1, z: -0, w: -0.00000004371139}
+  m_LocalPosition: {x: 3, y: 0, z: -6}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1828072468542817161}
+  - {fileID: 1828072467869257801}
+  m_Father: {fileID: 1828072467343233353}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072467243072735
 GameObject:
   m_ObjectHideFlags: 0
@@ -15944,7 +16130,7 @@ Transform:
   - {fileID: 1828072467573389161}
   - {fileID: 1828072467459648972}
   - {fileID: 1828072468436860117}
-  - {fileID: 1828072466895680839}
+  - {fileID: 1828072466745728139}
   - {fileID: 1828072468288821332}
   - {fileID: 1828072467150803965}
   - {fileID: 1828072467710209011}
@@ -16487,11 +16673,11 @@ Transform:
   m_Children:
   - {fileID: 1828072466587123414}
   - {fileID: 1828072467135507945}
-  - {fileID: 1828072468542817161}
+  - {fileID: 1828072467238474973}
   - {fileID: 1828072468449797517}
   - {fileID: 1828072468471041367}
   - {fileID: 1828072468154860112}
-  - {fileID: 1828072467601158192}
+  - {fileID: 1828072466616357472}
   - {fileID: 1828072466564619533}
   - {fileID: 1828072468147157946}
   - {fileID: 1828072467057556110}
@@ -17502,6 +17688,39 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &1828072467395161645
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1828072467395161644}
+  m_Layer: 0
+  m_Name: Tile_x(8)_z(10)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1828072467395161644
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1828072467395161645}
+  m_LocalRotation: {x: -0, y: 1, z: -0, w: -0.00000004371139}
+  m_LocalPosition: {x: 8, y: 0, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1828072467427259937}
+  - {fileID: 1828072467875210546}
+  m_Father: {fileID: 1828072466884861296}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072467411935621
 GameObject:
   m_ObjectHideFlags: 0
@@ -17963,9 +18182,8 @@ GameObject:
   - component: {fileID: 1828072467427259938}
   - component: {fileID: 1828072467427259939}
   - component: {fileID: 1828072467427259936}
-  - component: {fileID: 75325089179198334}
   m_Layer: 0
-  m_Name: Tile_x(8)_z(10)
+  m_Name: pipe_X_LOD0
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -17978,15 +18196,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1828072467427259950}
-  m_LocalRotation: {x: -0, y: 1, z: -0, w: -0.00000004371139}
-  m_LocalPosition: {x: 8, y: 1, z: -10}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1828072468440077285}
-  - {fileID: 1828072467875210546}
-  m_Father: {fileID: 1828072466884861296}
-  m_RootOrder: 7
+  m_Father: {fileID: 1828072467395161644}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &1828072467427259940
 MeshFilter:
@@ -18070,7 +18287,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59a25a69e624bd24ca2d80c531be02f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _innerObjs: []
+  shrinkRate: 0.1
 --- !u!114 &1828072467427259936
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -18093,19 +18310,6 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
---- !u!65 &75325089179198334
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1828072467427259950}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 1, y: 0.953548, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072467427356710
 GameObject:
   m_ObjectHideFlags: 0
@@ -18191,12 +18395,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1828072467433378510}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: -1, z: 0}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1828072468133137351}
+  m_Father: {fileID: 1828072466789206705}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072467437680554
@@ -21228,9 +21432,8 @@ GameObject:
   - component: {fileID: 1828072467601158197}
   - component: {fileID: 1828072467601158194}
   - component: {fileID: 1828072467601158195}
-  - component: {fileID: 3873215968716797583}
   m_Layer: 0
-  m_Name: Tile_x(7)_z(6)
+  m_Name: pipe_X_LOD0
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -21243,15 +21446,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1828072467601158193}
-  m_LocalRotation: {x: -0, y: 1, z: -0, w: -0.00000004371139}
-  m_LocalPosition: {x: 7, y: 1, z: -6}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1828072467179336373}
-  - {fileID: 1828072466563840271}
-  m_Father: {fileID: 1828072467343233353}
-  m_RootOrder: 6
+  m_Father: {fileID: 1828072466616357472}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &1828072467601158199
 MeshFilter:
@@ -21335,7 +21537,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59a25a69e624bd24ca2d80c531be02f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _innerObjs: []
+  shrinkRate: 0.1
 --- !u!114 &1828072467601158195
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -21358,19 +21560,6 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
---- !u!65 &3873215968716797583
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1828072467601158193}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 1, y: 0.953548, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072467605742355
 GameObject:
   m_ObjectHideFlags: 0
@@ -21760,12 +21949,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1828072467665146487}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: -1, z: 0}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1828072468133465298}
+  m_Father: {fileID: 1828072468224380250}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072467666372077
@@ -25321,12 +25510,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1828072467869257846}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: -1, z: 0}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1828072468542817161}
+  m_Father: {fileID: 1828072467238474973}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072467875210547
@@ -25352,12 +25541,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1828072467875210547}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: -1, z: 0}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1828072467427259937}
+  m_Father: {fileID: 1828072467395161644}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072467875370403
@@ -29262,9 +29451,8 @@ GameObject:
   - component: {fileID: 1828072468133137368}
   - component: {fileID: 1828072468133137369}
   - component: {fileID: 1828072468133137350}
-  - component: {fileID: 4684567582776988050}
   m_Layer: 0
-  m_Name: Tile_x(10)_z(2)
+  m_Name: pipe_X_LOD0
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -29277,15 +29465,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1828072468133137348}
-  m_LocalRotation: {x: -0, y: 1, z: -0, w: -0.00000004371139}
-  m_LocalPosition: {x: 10, y: 1, z: -2}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1828072466785396728}
-  - {fileID: 1828072467433378497}
-  m_Father: {fileID: 1828072468552108882}
-  m_RootOrder: 8
+  m_Father: {fileID: 1828072466789206705}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &1828072468133137370
 MeshFilter:
@@ -29369,7 +29556,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59a25a69e624bd24ca2d80c531be02f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _innerObjs: []
+  shrinkRate: 0.1
 --- !u!114 &1828072468133137350
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -29392,19 +29579,6 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
---- !u!65 &4684567582776988050
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1828072468133137348}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 1, y: 0.953548, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072468133465299
 GameObject:
   m_ObjectHideFlags: 0
@@ -29419,9 +29593,8 @@ GameObject:
   - component: {fileID: 1828072468133465303}
   - component: {fileID: 1828072468133465300}
   - component: {fileID: 1828072468133465301}
-  - component: {fileID: 6870912794154870859}
   m_Layer: 0
-  m_Name: Tile_x(14)_z(10)
+  m_Name: pipe_X_LOD0
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -29434,15 +29607,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1828072468133465299}
-  m_LocalRotation: {x: -0, y: 1, z: -0, w: -0.00000004371139}
-  m_LocalPosition: {x: 14, y: 1, z: -10}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1828072467077803951}
-  - {fileID: 1828072467665146486}
-  m_Father: {fileID: 1828072466884861296}
-  m_RootOrder: 12
+  m_Father: {fileID: 1828072468224380250}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &1828072468133465257
 MeshFilter:
@@ -29526,7 +29698,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59a25a69e624bd24ca2d80c531be02f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _innerObjs: []
+  shrinkRate: 0.1
 --- !u!114 &1828072468133465301
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -29549,19 +29721,6 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
---- !u!65 &6870912794154870859
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1828072468133465299}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 1, y: 0.953548, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072468135439226
 GameObject:
   m_ObjectHideFlags: 0
@@ -30965,6 +31124,39 @@ Transform:
   m_Father: {fileID: 1828072468384866787}
   m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1828072468224380251
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1828072468224380250}
+  m_Layer: 0
+  m_Name: Tile_x(14)_z(10)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1828072468224380250
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1828072468224380251}
+  m_LocalRotation: {x: -0, y: 1, z: -0, w: -0.00000004371139}
+  m_LocalPosition: {x: 14, y: 0, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1828072468133465298}
+  - {fileID: 1828072467665146486}
+  m_Father: {fileID: 1828072466884861296}
+  m_RootOrder: 12
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072468226203138
 GameObject:
   m_ObjectHideFlags: 0
@@ -32227,12 +32419,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1828072468276407478}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: -1, z: 0}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1828072468403328176}
+  m_Father: {fileID: 1828072466679693289}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072468285017850
@@ -34162,9 +34354,8 @@ GameObject:
   - component: {fileID: 1828072468403328181}
   - component: {fileID: 1828072468403328178}
   - component: {fileID: 1828072468403328179}
-  - component: {fileID: 4756824478082062109}
   m_Layer: 0
-  m_Name: Tile_x(11)_z(5)
+  m_Name: pipe_X_LOD0
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -34177,15 +34368,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1828072468403328177}
-  m_LocalRotation: {x: -0, y: 1, z: -0, w: -0.00000004371139}
-  m_LocalPosition: {x: 11, y: 1, z: -5}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1828072467394339313}
-  - {fileID: 1828072468276407433}
-  m_Father: {fileID: 1828072466535608645}
-  m_RootOrder: 10
+  m_Father: {fileID: 1828072466679693289}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &1828072468403328183
 MeshFilter:
@@ -34269,7 +34459,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59a25a69e624bd24ca2d80c531be02f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _innerObjs: []
+  shrinkRate: 0.1
 --- !u!114 &1828072468403328179
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -34292,19 +34482,6 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
---- !u!65 &4756824478082062109
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1828072468403328177}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 1, y: 0.953548, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072468404259752
 GameObject:
   m_ObjectHideFlags: 0
@@ -36422,12 +36599,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1828072468523452666}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: -1, z: 0}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1828072467153212993}
+  m_Father: {fileID: 1828072466455825902}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072468524965713
@@ -36716,9 +36893,8 @@ GameObject:
   - component: {fileID: 1828072468542817162}
   - component: {fileID: 1828072468542817163}
   - component: {fileID: 1828072468542817160}
-  - component: {fileID: 7162607827435827214}
   m_Layer: 0
-  m_Name: Tile_x(3)_z(6)
+  m_Name: pipe_X_LOD0
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -36731,15 +36907,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1828072468542817206}
-  m_LocalRotation: {x: -0, y: 1, z: -0, w: -0.00000004371139}
-  m_LocalPosition: {x: 3, y: 1, z: -6}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1828072467206518306}
-  - {fileID: 1828072467869257801}
-  m_Father: {fileID: 1828072467343233353}
-  m_RootOrder: 2
+  m_Father: {fileID: 1828072467238474973}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &1828072468542817164
 MeshFilter:
@@ -36823,7 +36998,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59a25a69e624bd24ca2d80c531be02f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _innerObjs: []
+  shrinkRate: 0.1
 --- !u!114 &1828072468542817160
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -36846,19 +37021,6 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
---- !u!65 &7162607827435827214
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1828072468542817206}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 1, y: 0.953548, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072468543972837
 GameObject:
   m_ObjectHideFlags: 0
@@ -37039,7 +37201,7 @@ Transform:
   - {fileID: 1828072468197448148}
   - {fileID: 1828072466788279937}
   - {fileID: 1828072468327652068}
-  - {fileID: 1828072468133137351}
+  - {fileID: 1828072466789206705}
   - {fileID: 1828072467243072734}
   - {fileID: 1828072466883008126}
   - {fileID: 1828072468272971831}

--- a/Assets/Develop/KMS/Prefabs/MapPrefabs/Forest07.prefab
+++ b/Assets/Develop/KMS/Prefabs/MapPrefabs/Forest07.prefab
@@ -726,39 +726,6 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 1, y: 1.0867765, z: 1}
   m_Center: {x: 0, y: 0.00039952993, z: 0.0010752678}
---- !u!1 &1828072466455825903
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1828072466455825902}
-  m_Layer: 0
-  m_Name: Tile_x(4)_z(10)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1828072466455825902
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1828072466455825903}
-  m_LocalRotation: {x: -0, y: 1, z: -0, w: -0.00000004371139}
-  m_LocalPosition: {x: 4, y: 0, z: -10}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1828072467153212993}
-  - {fileID: 1828072468523452669}
-  m_Father: {fileID: 1828072466884861296}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072466456228178
 GameObject:
   m_ObjectHideFlags: 0
@@ -813,12 +780,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1828072466457896474}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: -1, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1828072466745728139}
+  m_Father: {fileID: 1828072466895680839}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072466464591812
@@ -979,8 +946,9 @@ GameObject:
   - component: {fileID: 1828072466466845273}
   - component: {fileID: 1828072466466845254}
   - component: {fileID: 1828072466466845255}
+  - component: {fileID: 5292812745763790072}
   m_Layer: 0
-  m_Name: pipe_X_LOD0
+  m_Name: Tile_x(14)_z(5)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -993,14 +961,15 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1828072466466845253}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 1, z: 0}
+  m_LocalRotation: {x: -0, y: 1, z: -0, w: -0.00000004371139}
+  m_LocalPosition: {x: 14, y: 1, z: -5}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1828072466647081775}
-  m_Father: {fileID: 1828072466599096580}
-  m_RootOrder: 0
+  - {fileID: 1828072467032029537}
+  m_Father: {fileID: 1828072466535608645}
+  m_RootOrder: 13
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &1828072466466845275
 MeshFilter:
@@ -1084,7 +1053,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59a25a69e624bd24ca2d80c531be02f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  shrinkRate: 0.1
+  _innerObjs: []
 --- !u!114 &1828072466466845255
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1107,6 +1076,19 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
+--- !u!65 &5292812745763790072
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1828072466466845253}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 0.953548, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072466469086081
 GameObject:
   m_ObjectHideFlags: 0
@@ -2271,10 +2253,10 @@ Transform:
   - {fileID: 1828072468266326407}
   - {fileID: 1828072468068710143}
   - {fileID: 1828072468471288328}
-  - {fileID: 1828072466679693289}
+  - {fileID: 1828072468403328176}
   - {fileID: 1828072466885812092}
   - {fileID: 1828072467261945406}
-  - {fileID: 1828072466599096580}
+  - {fileID: 1828072466466845252}
   - {fileID: 1828072467051846467}
   - {fileID: 1828072466517897714}
   m_Father: {fileID: 1828072467680842488}
@@ -2610,12 +2592,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1828072466563840268}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: -1, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1828072466616357472}
+  m_Father: {fileID: 1828072467601158192}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072466564619530
@@ -3162,39 +3144,6 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
---- !u!1 &1828072466599096581
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1828072466599096580}
-  m_Layer: 0
-  m_Name: Tile_x(14)_z(5)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1828072466599096580
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1828072466599096581}
-  m_LocalRotation: {x: -0, y: 1, z: -0, w: -0.00000004371139}
-  m_LocalPosition: {x: 14, y: 0, z: -5}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1828072466466845252}
-  - {fileID: 1828072467032029537}
-  m_Father: {fileID: 1828072466535608645}
-  m_RootOrder: 13
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072466616168211
 GameObject:
   m_ObjectHideFlags: 0
@@ -3339,39 +3288,6 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
---- !u!1 &1828072466616357473
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1828072466616357472}
-  m_Layer: 0
-  m_Name: Tile_x(7)_z(6)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1828072466616357472
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1828072466616357473}
-  m_LocalRotation: {x: -0, y: 1, z: -0, w: -0.00000004371139}
-  m_LocalPosition: {x: 7, y: 0, z: -6}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1828072467601158192}
-  - {fileID: 1828072466563840271}
-  m_Father: {fileID: 1828072467343233353}
-  m_RootOrder: 6
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072466619956608
 GameObject:
   m_ObjectHideFlags: 0
@@ -3987,39 +3903,6 @@ Transform:
   - {fileID: 1828072467081844972}
   m_Father: {fileID: 1828072466774537543}
   m_RootOrder: 6
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1828072466679692822
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1828072466679693289}
-  m_Layer: 0
-  m_Name: Tile_x(11)_z(5)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1828072466679693289
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1828072466679692822}
-  m_LocalRotation: {x: -0, y: 1, z: -0, w: -0.00000004371139}
-  m_LocalPosition: {x: 11, y: 0, z: -5}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1828072468403328176}
-  - {fileID: 1828072468276407433}
-  m_Father: {fileID: 1828072466535608645}
-  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072466680645821
 GameObject:
@@ -5603,39 +5486,6 @@ Transform:
   m_Father: {fileID: 1828072467680842488}
   m_RootOrder: 12
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1828072466745728136
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1828072466745728139}
-  m_Layer: 0
-  m_Name: Tile_x(3)_z(4)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1828072466745728139
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1828072466745728136}
-  m_LocalRotation: {x: -0, y: 1, z: -0, w: -0.00000004371139}
-  m_LocalPosition: {x: 3, y: 0, z: -4}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1828072466895680839}
-  - {fileID: 1828072466457896477}
-  m_Father: {fileID: 1828072467312348390}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072466748584482
 GameObject:
   m_ObjectHideFlags: 0
@@ -6213,39 +6063,6 @@ Transform:
   - {fileID: 1828072466650911004}
   m_Father: {fileID: 1828072468552108882}
   m_RootOrder: 6
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1828072466789206718
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1828072466789206705}
-  m_Layer: 0
-  m_Name: Tile_x(10)_z(2)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1828072466789206705
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1828072466789206718}
-  m_LocalRotation: {x: -0, y: 1, z: -0, w: -0.00000004371139}
-  m_LocalPosition: {x: 10, y: 0, z: -2}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1828072468133137351}
-  - {fileID: 1828072467433378497}
-  m_Father: {fileID: 1828072468552108882}
-  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072466795274927
 GameObject:
@@ -7767,16 +7584,16 @@ Transform:
   - {fileID: 1828072466480312874}
   - {fileID: 1828072467666372076}
   - {fileID: 1828072466917088504}
-  - {fileID: 1828072466455825902}
+  - {fileID: 1828072467153212993}
   - {fileID: 1828072467097792783}
   - {fileID: 1828072467751162725}
   - {fileID: 1828072467190787372}
-  - {fileID: 1828072467395161644}
+  - {fileID: 1828072467427259937}
   - {fileID: 1828072466773949940}
   - {fileID: 1828072468459210376}
   - {fileID: 1828072467593079229}
   - {fileID: 1828072467391626548}
-  - {fileID: 1828072468224380250}
+  - {fileID: 1828072468133465298}
   - {fileID: 1828072466512633531}
   - {fileID: 1828072466831034477}
   m_Father: {fileID: 1828072467680842488}
@@ -7829,8 +7646,9 @@ GameObject:
   - component: {fileID: 1828072466895680856}
   - component: {fileID: 1828072466895680857}
   - component: {fileID: 1828072466895680838}
+  - component: {fileID: 5686626070234464567}
   m_Layer: 0
-  m_Name: pipe_X_LOD0
+  m_Name: Tile_x(3)_z(4)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -7843,14 +7661,15 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1828072466895680836}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 1, z: 0}
+  m_LocalRotation: {x: -0, y: 1, z: -0, w: -0.00000004371139}
+  m_LocalPosition: {x: 3, y: 1, z: -4}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1828072466643041551}
-  m_Father: {fileID: 1828072466745728139}
-  m_RootOrder: 0
+  - {fileID: 1828072466457896477}
+  m_Father: {fileID: 1828072467312348390}
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &1828072466895680858
 MeshFilter:
@@ -7934,7 +7753,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59a25a69e624bd24ca2d80c531be02f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  shrinkRate: 0.1
+  _innerObjs: []
 --- !u!114 &1828072466895680838
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -7957,6 +7776,19 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
+--- !u!65 &5686626070234464567
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1828072466895680836}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 0.953548, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072466896088262
 GameObject:
   m_ObjectHideFlags: 0
@@ -10568,12 +10400,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1828072467032029550}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: -1, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1828072466599096580}
+  m_Father: {fileID: 1828072466466845252}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072467033491191
@@ -12765,8 +12597,9 @@ GameObject:
   - component: {fileID: 1828072467153212994}
   - component: {fileID: 1828072467153212995}
   - component: {fileID: 1828072467153212992}
+  - component: {fileID: 55918244286903656}
   m_Layer: 0
-  m_Name: pipe_X_LOD0
+  m_Name: Tile_x(4)_z(10)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -12779,14 +12612,15 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1828072467153213006}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 1, z: 0}
+  m_LocalRotation: {x: -0, y: 1, z: -0, w: -0.00000004371139}
+  m_LocalPosition: {x: 4, y: 1, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1828072467522755429}
-  m_Father: {fileID: 1828072466455825902}
-  m_RootOrder: 0
+  - {fileID: 1828072468523452669}
+  m_Father: {fileID: 1828072466884861296}
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &1828072467153212996
 MeshFilter:
@@ -12870,7 +12704,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59a25a69e624bd24ca2d80c531be02f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  shrinkRate: 0.1
+  _innerObjs: []
 --- !u!114 &1828072467153212992
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -12893,6 +12727,19 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
+--- !u!65 &55918244286903656
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1828072467153213006}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 0.953548, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072467160703214
 GameObject:
   m_ObjectHideFlags: 0
@@ -15149,39 +14996,6 @@ Transform:
   m_Father: {fileID: 1828072467315392315}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1828072467238474970
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1828072467238474973}
-  m_Layer: 0
-  m_Name: Tile_x(3)_z(6)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1828072467238474973
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1828072467238474970}
-  m_LocalRotation: {x: -0, y: 1, z: -0, w: -0.00000004371139}
-  m_LocalPosition: {x: 3, y: 0, z: -6}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1828072468542817161}
-  - {fileID: 1828072467869257801}
-  m_Father: {fileID: 1828072467343233353}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072467243072735
 GameObject:
   m_ObjectHideFlags: 0
@@ -16130,7 +15944,7 @@ Transform:
   - {fileID: 1828072467573389161}
   - {fileID: 1828072467459648972}
   - {fileID: 1828072468436860117}
-  - {fileID: 1828072466745728139}
+  - {fileID: 1828072466895680839}
   - {fileID: 1828072468288821332}
   - {fileID: 1828072467150803965}
   - {fileID: 1828072467710209011}
@@ -16673,11 +16487,11 @@ Transform:
   m_Children:
   - {fileID: 1828072466587123414}
   - {fileID: 1828072467135507945}
-  - {fileID: 1828072467238474973}
+  - {fileID: 1828072468542817161}
   - {fileID: 1828072468449797517}
   - {fileID: 1828072468471041367}
   - {fileID: 1828072468154860112}
-  - {fileID: 1828072466616357472}
+  - {fileID: 1828072467601158192}
   - {fileID: 1828072466564619533}
   - {fileID: 1828072468147157946}
   - {fileID: 1828072467057556110}
@@ -17688,39 +17502,6 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!1 &1828072467395161645
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1828072467395161644}
-  m_Layer: 0
-  m_Name: Tile_x(8)_z(10)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1828072467395161644
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1828072467395161645}
-  m_LocalRotation: {x: -0, y: 1, z: -0, w: -0.00000004371139}
-  m_LocalPosition: {x: 8, y: 0, z: -10}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1828072467427259937}
-  - {fileID: 1828072467875210546}
-  m_Father: {fileID: 1828072466884861296}
-  m_RootOrder: 7
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072467411935621
 GameObject:
   m_ObjectHideFlags: 0
@@ -18182,8 +17963,9 @@ GameObject:
   - component: {fileID: 1828072467427259938}
   - component: {fileID: 1828072467427259939}
   - component: {fileID: 1828072467427259936}
+  - component: {fileID: 75325089179198334}
   m_Layer: 0
-  m_Name: pipe_X_LOD0
+  m_Name: Tile_x(8)_z(10)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -18196,14 +17978,15 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1828072467427259950}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 1, z: 0}
+  m_LocalRotation: {x: -0, y: 1, z: -0, w: -0.00000004371139}
+  m_LocalPosition: {x: 8, y: 1, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1828072468440077285}
-  m_Father: {fileID: 1828072467395161644}
-  m_RootOrder: 0
+  - {fileID: 1828072467875210546}
+  m_Father: {fileID: 1828072466884861296}
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &1828072467427259940
 MeshFilter:
@@ -18287,7 +18070,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59a25a69e624bd24ca2d80c531be02f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  shrinkRate: 0.1
+  _innerObjs: []
 --- !u!114 &1828072467427259936
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -18310,6 +18093,19 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
+--- !u!65 &75325089179198334
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1828072467427259950}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 0.953548, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072467427356710
 GameObject:
   m_ObjectHideFlags: 0
@@ -18395,12 +18191,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1828072467433378510}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: -1, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1828072466789206705}
+  m_Father: {fileID: 1828072468133137351}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072467437680554
@@ -21432,8 +21228,9 @@ GameObject:
   - component: {fileID: 1828072467601158197}
   - component: {fileID: 1828072467601158194}
   - component: {fileID: 1828072467601158195}
+  - component: {fileID: 3873215968716797583}
   m_Layer: 0
-  m_Name: pipe_X_LOD0
+  m_Name: Tile_x(7)_z(6)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -21446,14 +21243,15 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1828072467601158193}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 1, z: 0}
+  m_LocalRotation: {x: -0, y: 1, z: -0, w: -0.00000004371139}
+  m_LocalPosition: {x: 7, y: 1, z: -6}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1828072467179336373}
-  m_Father: {fileID: 1828072466616357472}
-  m_RootOrder: 0
+  - {fileID: 1828072466563840271}
+  m_Father: {fileID: 1828072467343233353}
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &1828072467601158199
 MeshFilter:
@@ -21537,7 +21335,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59a25a69e624bd24ca2d80c531be02f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  shrinkRate: 0.1
+  _innerObjs: []
 --- !u!114 &1828072467601158195
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -21560,6 +21358,19 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
+--- !u!65 &3873215968716797583
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1828072467601158193}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 0.953548, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072467605742355
 GameObject:
   m_ObjectHideFlags: 0
@@ -21949,12 +21760,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1828072467665146487}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: -1, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1828072468224380250}
+  m_Father: {fileID: 1828072468133465298}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072467666372077
@@ -25510,12 +25321,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1828072467869257846}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: -1, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1828072467238474973}
+  m_Father: {fileID: 1828072468542817161}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072467875210547
@@ -25541,12 +25352,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1828072467875210547}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: -1, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1828072467395161644}
+  m_Father: {fileID: 1828072467427259937}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072467875370403
@@ -29451,8 +29262,9 @@ GameObject:
   - component: {fileID: 1828072468133137368}
   - component: {fileID: 1828072468133137369}
   - component: {fileID: 1828072468133137350}
+  - component: {fileID: 4684567582776988050}
   m_Layer: 0
-  m_Name: pipe_X_LOD0
+  m_Name: Tile_x(10)_z(2)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -29465,14 +29277,15 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1828072468133137348}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 1, z: 0}
+  m_LocalRotation: {x: -0, y: 1, z: -0, w: -0.00000004371139}
+  m_LocalPosition: {x: 10, y: 1, z: -2}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1828072466785396728}
-  m_Father: {fileID: 1828072466789206705}
-  m_RootOrder: 0
+  - {fileID: 1828072467433378497}
+  m_Father: {fileID: 1828072468552108882}
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &1828072468133137370
 MeshFilter:
@@ -29556,7 +29369,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59a25a69e624bd24ca2d80c531be02f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  shrinkRate: 0.1
+  _innerObjs: []
 --- !u!114 &1828072468133137350
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -29579,6 +29392,19 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
+--- !u!65 &4684567582776988050
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1828072468133137348}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 0.953548, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072468133465299
 GameObject:
   m_ObjectHideFlags: 0
@@ -29593,8 +29419,9 @@ GameObject:
   - component: {fileID: 1828072468133465303}
   - component: {fileID: 1828072468133465300}
   - component: {fileID: 1828072468133465301}
+  - component: {fileID: 6870912794154870859}
   m_Layer: 0
-  m_Name: pipe_X_LOD0
+  m_Name: Tile_x(14)_z(10)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -29607,14 +29434,15 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1828072468133465299}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 1, z: 0}
+  m_LocalRotation: {x: -0, y: 1, z: -0, w: -0.00000004371139}
+  m_LocalPosition: {x: 14, y: 1, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1828072467077803951}
-  m_Father: {fileID: 1828072468224380250}
-  m_RootOrder: 0
+  - {fileID: 1828072467665146486}
+  m_Father: {fileID: 1828072466884861296}
+  m_RootOrder: 12
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &1828072468133465257
 MeshFilter:
@@ -29698,7 +29526,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59a25a69e624bd24ca2d80c531be02f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  shrinkRate: 0.1
+  _innerObjs: []
 --- !u!114 &1828072468133465301
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -29721,6 +29549,19 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
+--- !u!65 &6870912794154870859
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1828072468133465299}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 0.953548, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072468135439226
 GameObject:
   m_ObjectHideFlags: 0
@@ -31124,39 +30965,6 @@ Transform:
   m_Father: {fileID: 1828072468384866787}
   m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1828072468224380251
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1828072468224380250}
-  m_Layer: 0
-  m_Name: Tile_x(14)_z(10)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1828072468224380250
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1828072468224380251}
-  m_LocalRotation: {x: -0, y: 1, z: -0, w: -0.00000004371139}
-  m_LocalPosition: {x: 14, y: 0, z: -10}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1828072468133465298}
-  - {fileID: 1828072467665146486}
-  m_Father: {fileID: 1828072466884861296}
-  m_RootOrder: 12
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072468226203138
 GameObject:
   m_ObjectHideFlags: 0
@@ -32419,12 +32227,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1828072468276407478}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: -1, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1828072466679693289}
+  m_Father: {fileID: 1828072468403328176}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072468285017850
@@ -34354,8 +34162,9 @@ GameObject:
   - component: {fileID: 1828072468403328181}
   - component: {fileID: 1828072468403328178}
   - component: {fileID: 1828072468403328179}
+  - component: {fileID: 4756824478082062109}
   m_Layer: 0
-  m_Name: pipe_X_LOD0
+  m_Name: Tile_x(11)_z(5)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -34368,14 +34177,15 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1828072468403328177}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 1, z: 0}
+  m_LocalRotation: {x: -0, y: 1, z: -0, w: -0.00000004371139}
+  m_LocalPosition: {x: 11, y: 1, z: -5}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1828072467394339313}
-  m_Father: {fileID: 1828072466679693289}
-  m_RootOrder: 0
+  - {fileID: 1828072468276407433}
+  m_Father: {fileID: 1828072466535608645}
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &1828072468403328183
 MeshFilter:
@@ -34459,7 +34269,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59a25a69e624bd24ca2d80c531be02f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  shrinkRate: 0.1
+  _innerObjs: []
 --- !u!114 &1828072468403328179
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -34482,6 +34292,19 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
+--- !u!65 &4756824478082062109
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1828072468403328177}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 0.953548, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072468404259752
 GameObject:
   m_ObjectHideFlags: 0
@@ -36599,12 +36422,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1828072468523452666}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: -1, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1828072466455825902}
+  m_Father: {fileID: 1828072467153212993}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072468524965713
@@ -36893,8 +36716,9 @@ GameObject:
   - component: {fileID: 1828072468542817162}
   - component: {fileID: 1828072468542817163}
   - component: {fileID: 1828072468542817160}
+  - component: {fileID: 7162607827435827214}
   m_Layer: 0
-  m_Name: pipe_X_LOD0
+  m_Name: Tile_x(3)_z(6)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -36907,14 +36731,15 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1828072468542817206}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 1, z: 0}
+  m_LocalRotation: {x: -0, y: 1, z: -0, w: -0.00000004371139}
+  m_LocalPosition: {x: 3, y: 1, z: -6}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1828072467206518306}
-  m_Father: {fileID: 1828072467238474973}
-  m_RootOrder: 0
+  - {fileID: 1828072467869257801}
+  m_Father: {fileID: 1828072467343233353}
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &1828072468542817164
 MeshFilter:
@@ -36998,7 +36823,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59a25a69e624bd24ca2d80c531be02f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  shrinkRate: 0.1
+  _innerObjs: []
 --- !u!114 &1828072468542817160
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -37021,6 +36846,19 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
+--- !u!65 &7162607827435827214
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1828072468542817206}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 0.953548, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &1828072468543972837
 GameObject:
   m_ObjectHideFlags: 0
@@ -37201,7 +37039,7 @@ Transform:
   - {fileID: 1828072468197448148}
   - {fileID: 1828072466788279937}
   - {fileID: 1828072468327652068}
-  - {fileID: 1828072466789206705}
+  - {fileID: 1828072468133137351}
   - {fileID: 1828072467243072734}
   - {fileID: 1828072466883008126}
   - {fileID: 1828072468272971831}

--- a/Assets/Develop/KMS/Prefabs/MapPrefabs/IceMap.prefab
+++ b/Assets/Develop/KMS/Prefabs/MapPrefabs/IceMap.prefab
@@ -23,13 +23,79 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7142995572822328}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -6, y: -1, z: 13}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 5915593302059509969}
+  m_Father: {fileID: 3579426480509295461}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &90297896690709902
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3579426480509295461}
+  m_Layer: 0
+  m_Name: Tile_x(6)_z(13)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3579426480509295461
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 90297896690709902}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5915593302059509969}
+  - {fileID: 4102981382755705216}
+  m_Father: {fileID: 1567488187209773589}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &224340265487962523
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8251430844763580979}
+  m_Layer: 0
+  m_Name: Tile_x(6)_z(11)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8251430844763580979
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 224340265487962523}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1273395938993616616}
+  - {fileID: 6926803871487988217}
+  m_Father: {fileID: 1567488188900932962}
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &482616946720320233
 GameObject:
@@ -54,12 +120,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 482616946720320233}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -6, y: -1, z: 5}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 3421753788498467197}
+  m_Father: {fileID: 3810267629735825826}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &894250392368678465
@@ -116,13 +182,46 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 960306928633623989}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -10, y: -1, z: 3}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 8892531631797268839}
+  m_Father: {fileID: 1897303266576198582}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &964296557568495287
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8523437079741894935}
+  m_Layer: 0
+  m_Name: Tile_x(10)_z(13)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8523437079741894935
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 964296557568495287}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4649993659239318855}
+  - {fileID: 5101680558904477458}
+  m_Father: {fileID: 1567488187209773589}
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1024059423751469859
 GameObject:
@@ -138,9 +237,8 @@ GameObject:
   - component: {fileID: 6708596083029678293}
   - component: {fileID: 4898531213166309430}
   - component: {fileID: 4737047836247342650}
-  - component: {fileID: 4317117753639961468}
   m_Layer: 0
-  m_Name: Tile_x(10)_z(3)
+  m_Name: pipe_X_LOD0
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -159,9 +257,8 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 6701753571202102057}
-  - {fileID: 3879969931744704031}
-  m_Father: {fileID: 1567488187523748374}
-  m_RootOrder: 10
+  m_Father: {fileID: 1897303266576198582}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &3800495337848546824
 MeshFilter:
@@ -245,7 +342,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59a25a69e624bd24ca2d80c531be02f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _innerObjs: []
+  shrinkRate: 0.1
 --- !u!114 &4737047836247342650
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -268,19 +365,6 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
---- !u!65 &4317117753639961468
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1024059423751469859}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 1, y: 0.953548, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &1137968714718580854
 GameObject:
   m_ObjectHideFlags: 0
@@ -304,12 +388,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1137968714718580854}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -10, y: -1, z: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 4487545347565076754}
+  m_Father: {fileID: 8872323832016394516}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1390314533824695887
@@ -326,9 +410,8 @@ GameObject:
   - component: {fileID: 4791618920059969617}
   - component: {fileID: 736416223019761346}
   - component: {fileID: 804578433319035726}
-  - component: {fileID: 2219583650071131262}
   m_Layer: 0
-  m_Name: Tile_x(6)_z(1)
+  m_Name: pipe_X_LOD0
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -347,9 +430,8 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 3990553086189911762}
-  - {fileID: 2006379573018671537}
-  m_Father: {fileID: 1567488188810661924}
-  m_RootOrder: 5
+  m_Father: {fileID: 2852209720836286954}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &5283053487624458036
 MeshFilter:
@@ -417,7 +499,7 @@ MonoBehaviour:
   explosionForce: 30
   explosionRadius: 5
   fragmentPrefab: {fileID: 7583408258262586530, guid: a988a83306ff7bc4e9fdb0a1f73ffd1d, type: 3}
-  parentContainer: {fileID: 2006379573018671537}
+  parentContainer: {fileID: 8691622669510500422}
   itemPrefabs: []
   itemSpawnChance: 0
   isContinue: 0
@@ -433,7 +515,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59a25a69e624bd24ca2d80c531be02f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _innerObjs: []
+  shrinkRate: 0.1
 --- !u!114 &804578433319035726
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -456,19 +538,6 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
---- !u!65 &2219583650071131262
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1390314533824695887}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 1, y: 0.953548, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &1442785199544711174
 GameObject:
   m_ObjectHideFlags: 0
@@ -492,12 +561,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1442785199544711174}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -10, y: -1, z: 9}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 2281170754613537231}
+  m_Father: {fileID: 3502281692732303027}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1503386104060404580
@@ -523,12 +592,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1503386104060404580}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -6, y: -1, z: 9}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 7144287875862034197}
+  m_Father: {fileID: 3547579488268943688}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1567488187007431952
@@ -2576,10 +2645,10 @@ Transform:
   - {fileID: 1567488187408444141}
   - {fileID: 1567488187497291350}
   - {fileID: 1567488188643952007}
-  - {fileID: 5915593302059509969}
+  - {fileID: 3579426480509295461}
   - {fileID: 1567488188713901149}
   - {fileID: 8518042857321493399}
-  - {fileID: 4649993659239318855}
+  - {fileID: 8523437079741894935}
   - {fileID: 1567488188984977859}
   - {fileID: 1567488187239285923}
   - {fileID: 1567488187364665048}
@@ -7639,12 +7708,12 @@ Transform:
   - {fileID: 1567488188962112030}
   - {fileID: 1567488187454287112}
   - {fileID: 1567488188858855830}
-  - {fileID: 3164081151991609743}
+  - {fileID: 8771683364522783251}
   - {fileID: 1567488187435804922}
   - {fileID: 9104588635370025777}
   - {fileID: 1567488188126283702}
   - {fileID: 8205159744822741599}
-  - {fileID: 8892531631797268839}
+  - {fileID: 1897303266576198582}
   - {fileID: 1567488188182003503}
   - {fileID: 1567488188766198629}
   - {fileID: 1567488187775815215}
@@ -18042,11 +18111,11 @@ Transform:
   - {fileID: 1567488188525708013}
   - {fileID: 1567488187976739552}
   - {fileID: 1567488188248664878}
-  - {fileID: 5284973921428782978}
+  - {fileID: 8087554271394926862}
   - {fileID: 1567488188180807333}
   - {fileID: 4551534472062559587}
   - {fileID: 1567488187822679423}
-  - {fileID: 6636314211036263022}
+  - {fileID: 4993323737189854766}
   - {fileID: 1567488187771327213}
   - {fileID: 1567488187824951315}
   - {fileID: 1567488188882869421}
@@ -21327,10 +21396,10 @@ Transform:
   - {fileID: 1567488188074547803}
   - {fileID: 1567488188770295202}
   - {fileID: 1567488188382936881}
-  - {fileID: 3421753788498467197}
+  - {fileID: 3810267629735825826}
   - {fileID: 1567488189055560489}
   - {fileID: 6801656291037658990}
-  - {fileID: 4655418111188409184}
+  - {fileID: 9110935221043754606}
   - {fileID: 1567488187962867894}
   - {fileID: 1567488187777097678}
   - {fileID: 1567488188731258869}
@@ -22036,12 +22105,12 @@ Transform:
   - {fileID: 1567488188911626303}
   - {fileID: 1567488188489392809}
   - {fileID: 1567488187413795453}
-  - {fileID: 7144287875862034197}
+  - {fileID: 3547579488268943688}
   - {fileID: 1567488188798260698}
   - {fileID: 4405509430904419869}
   - {fileID: 1567488188991366145}
   - {fileID: 4875613094474180287}
-  - {fileID: 2281170754613537231}
+  - {fileID: 3502281692732303027}
   - {fileID: 1567488187730113915}
   - {fileID: 1567488188488679969}
   - {fileID: 1567488188118797873}
@@ -26657,11 +26726,11 @@ Transform:
   - {fileID: 1567488188478173603}
   - {fileID: 1567488187877859574}
   - {fileID: 1567488188766784420}
-  - {fileID: 4978785078781907030}
+  - {fileID: 2852209720836286954}
   - {fileID: 1567488187191303727}
   - {fileID: 1567488188398353427}
   - {fileID: 22312504237556946}
-  - {fileID: 4487545347565076754}
+  - {fileID: 8872323832016394516}
   - {fileID: 1567488188528283715}
   - {fileID: 1567488188787185957}
   - {fileID: 1567488187118084581}
@@ -27749,12 +27818,12 @@ Transform:
   - {fileID: 1567488188729249030}
   - {fileID: 1567488188223686941}
   - {fileID: 1567488187438542291}
-  - {fileID: 1273395938993616616}
+  - {fileID: 8251430844763580979}
   - {fileID: 1567488188123445248}
   - {fileID: 1567488187925985162}
   - {fileID: 3336523899463551914}
   - {fileID: 1567488187393259033}
-  - {fileID: 4804872217304578302}
+  - {fileID: 1379377831831995235}
   - {fileID: 1567488187265931960}
   - {fileID: 1567488187478243760}
   - {fileID: 1567488187894792351}
@@ -30359,6 +30428,70 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &1646686300559134861
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3547579488268943688}
+  m_Layer: 0
+  m_Name: Tile_x(6)_z(9)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3547579488268943688
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1646686300559134861}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7144287875862034197}
+  - {fileID: 1529594175050605339}
+  m_Father: {fileID: 1567488188570961927}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2162410545247695801
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8691622669510500422}
+  m_Layer: 0
+  m_Name: FragmentContainer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8691622669510500422
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2162410545247695801}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2852209720836286954}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2364142450599541351
 GameObject:
   m_ObjectHideFlags: 0
@@ -30442,6 +30575,72 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &2701330782019854148
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1897303266576198582}
+  m_Layer: 0
+  m_Name: Tile_x(10)_z(3)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1897303266576198582
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2701330782019854148}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8892531631797268839}
+  - {fileID: 3879969931744704031}
+  m_Father: {fileID: 1567488187523748374}
+  m_RootOrder: 10
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2702686288484436368
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9110935221043754606}
+  m_Layer: 0
+  m_Name: Tile_x(10)_z(5)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &9110935221043754606
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2702686288484436368}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4655418111188409184}
+  - {fileID: 1613727430099219279}
+  m_Father: {fileID: 1567488188503610875}
+  m_RootOrder: 10
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2771298537655461143
 GameObject:
   m_ObjectHideFlags: 0
@@ -30456,9 +30655,8 @@ GameObject:
   - component: {fileID: 6540724125610125222}
   - component: {fileID: 8840435227386660049}
   - component: {fileID: 6629820335149591238}
-  - component: {fileID: 7750977768225554567}
   m_Layer: 0
-  m_Name: Tile_x(10)_z(7)
+  m_Name: pipe_X_LOD0
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -30477,9 +30675,8 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 6001791638012703623}
-  - {fileID: 2633014539333715425}
-  m_Father: {fileID: 1567488188332870795}
-  m_RootOrder: 10
+  m_Father: {fileID: 4993323737189854766}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &3838505043354614685
 MeshFilter:
@@ -30563,7 +30760,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59a25a69e624bd24ca2d80c531be02f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _innerObjs: []
+  shrinkRate: 0.1
 --- !u!114 &6629820335149591238
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -30586,19 +30783,6 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
---- !u!65 &7750977768225554567
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2771298537655461143}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 1, y: 0.953548, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &2909088273934608759
 GameObject:
   m_ObjectHideFlags: 0
@@ -30705,12 +30889,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2953459837729298603}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -10, y: -1, z: 7}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 6636314211036263022}
+  m_Father: {fileID: 4993323737189854766}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &3057752347346393809
@@ -30879,6 +31063,138 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &3478084909563221976
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4993323737189854766}
+  m_Layer: 0
+  m_Name: Tile_x(10)_z(7)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4993323737189854766
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3478084909563221976}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6636314211036263022}
+  - {fileID: 2633014539333715425}
+  m_Father: {fileID: 1567488188332870795}
+  m_RootOrder: 10
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3578708194620930747
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8872323832016394516}
+  m_Layer: 0
+  m_Name: Tile_x(10)_z(1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8872323832016394516
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3578708194620930747}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4487545347565076754}
+  - {fileID: 7074400997766045757}
+  m_Father: {fileID: 1567488188810661924}
+  m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3668551226333700328
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8771683364522783251}
+  m_Layer: 0
+  m_Name: Tile_x(6)_z(3)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8771683364522783251
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3668551226333700328}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3164081151991609743}
+  - {fileID: 4080778824590815214}
+  m_Father: {fileID: 1567488187523748374}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3704295909494163657
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3502281692732303027}
+  m_Layer: 0
+  m_Name: Tile_x(10)_z(9)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3502281692732303027
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3704295909494163657}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2281170754613537231}
+  - {fileID: 5003108064067413627}
+  m_Father: {fileID: 1567488188570961927}
+  m_RootOrder: 11
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &3742220107718526250
 GameObject:
   m_ObjectHideFlags: 0
@@ -30893,9 +31209,8 @@ GameObject:
   - component: {fileID: 1344404815008971683}
   - component: {fileID: 2294532956304431377}
   - component: {fileID: 5315095390479977376}
-  - component: {fileID: 8777813085240412355}
   m_Layer: 0
-  m_Name: Tile_x(6)_z(7)
+  m_Name: pipe_X_LOD0
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -30914,9 +31229,8 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 3435243868315566918}
-  - {fileID: 4586240119026483438}
-  m_Father: {fileID: 1567488188332870795}
-  m_RootOrder: 6
+  m_Father: {fileID: 8087554271394926862}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &1916678605360133413
 MeshFilter:
@@ -31000,7 +31314,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59a25a69e624bd24ca2d80c531be02f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _innerObjs: []
+  shrinkRate: 0.1
 --- !u!114 &5315095390479977376
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -31023,19 +31337,6 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
---- !u!65 &8777813085240412355
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3742220107718526250}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 1, y: 0.953548, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &3989335685818720969
 GameObject:
   m_ObjectHideFlags: 0
@@ -31050,9 +31351,8 @@ GameObject:
   - component: {fileID: 2684787228258900918}
   - component: {fileID: 8963270498179820006}
   - component: {fileID: 7130333748135989767}
-  - component: {fileID: 6129329582037150433}
   m_Layer: 0
-  m_Name: Tile_x(10)_z(9)
+  m_Name: pipe_X_LOD0
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -31071,9 +31371,8 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 501229121830888392}
-  - {fileID: 5003108064067413627}
-  m_Father: {fileID: 1567488188570961927}
-  m_RootOrder: 11
+  m_Father: {fileID: 3502281692732303027}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &4940067658562093806
 MeshFilter:
@@ -31157,7 +31456,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59a25a69e624bd24ca2d80c531be02f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _innerObjs: []
+  shrinkRate: 0.1
 --- !u!114 &7130333748135989767
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -31180,19 +31479,6 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
---- !u!65 &6129329582037150433
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3989335685818720969}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 1, y: 0.953548, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &4012319597526903859
 GameObject:
   m_ObjectHideFlags: 0
@@ -31290,9 +31576,8 @@ GameObject:
   - component: {fileID: 5928543370093572941}
   - component: {fileID: 5694700581579388051}
   - component: {fileID: 609825458809976274}
-  - component: {fileID: 8686494004593973209}
   m_Layer: 0
-  m_Name: Tile_x(10)_z(13)
+  m_Name: pipe_X_LOD0
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -31311,9 +31596,8 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 5849852698455250300}
-  - {fileID: 5101680558904477458}
-  m_Father: {fileID: 1567488187209773589}
-  m_RootOrder: 9
+  m_Father: {fileID: 8523437079741894935}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &4683542501067419243
 MeshFilter:
@@ -31397,7 +31681,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59a25a69e624bd24ca2d80c531be02f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _innerObjs: []
+  shrinkRate: 0.1
 --- !u!114 &609825458809976274
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -31420,19 +31704,6 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
---- !u!65 &8686494004593973209
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4648439607111314511}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 1, y: 0.953548, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &4696500518300077999
 GameObject:
   m_ObjectHideFlags: 0
@@ -31456,12 +31727,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4696500518300077999}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -6, y: -1, z: 3}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 3164081151991609743}
+  m_Father: {fileID: 8771683364522783251}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &4807914589925829446
@@ -31575,9 +31846,8 @@ GameObject:
   - component: {fileID: 3274761612843986421}
   - component: {fileID: 6845525786612196162}
   - component: {fileID: 3770701011900556013}
-  - component: {fileID: 3419667109833754845}
   m_Layer: 0
-  m_Name: Tile_x(6)_z(3)
+  m_Name: pipe_X_LOD0
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -31596,9 +31866,8 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4601567130518626160}
-  - {fileID: 4080778824590815214}
-  m_Father: {fileID: 1567488187523748374}
-  m_RootOrder: 5
+  m_Father: {fileID: 8771683364522783251}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &2644920357513429559
 MeshFilter:
@@ -31682,7 +31951,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59a25a69e624bd24ca2d80c531be02f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _innerObjs: []
+  shrinkRate: 0.1
 --- !u!114 &3770701011900556013
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -31705,19 +31974,6 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
---- !u!65 &3419667109833754845
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5222915050822273686}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 1, y: 0.953548, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &5503825589449008385
 GameObject:
   m_ObjectHideFlags: 0
@@ -31741,12 +31997,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5503825589449008385}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -10, y: -1, z: 5}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 4655418111188409184}
+  m_Father: {fileID: 9110935221043754606}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &5584962602209813255
@@ -31763,9 +32019,8 @@ GameObject:
   - component: {fileID: 59932910338858441}
   - component: {fileID: 3111238701991913444}
   - component: {fileID: 3223165044494376908}
-  - component: {fileID: 6867091215370282929}
   m_Layer: 0
-  m_Name: Tile_x(6)_z(11)
+  m_Name: pipe_X_LOD0
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -31784,9 +32039,8 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4593043485488699891}
-  - {fileID: 6926803871487988217}
-  m_Father: {fileID: 1567488188900932962}
-  m_RootOrder: 5
+  m_Father: {fileID: 8251430844763580979}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &6435352105432244241
 MeshFilter:
@@ -31870,7 +32124,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59a25a69e624bd24ca2d80c531be02f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _innerObjs: []
+  shrinkRate: 0.1
 --- !u!114 &3223165044494376908
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -31893,20 +32147,7 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
---- !u!65 &6867091215370282929
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5584962602209813255}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 1, y: 0.953548, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!1 &5751103521344689457
+--- !u!1 &5706044351745849943
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -31914,28 +32155,63 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 2006379573018671537}
+  - component: {fileID: 2852209720836286954}
   m_Layer: 0
-  m_Name: FragmentContainer
+  m_Name: Tile_x(6)_z(1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &2006379573018671537
+--- !u!4 &2852209720836286954
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5751103521344689457}
+  m_GameObject: {fileID: 5706044351745849943}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -6, y: -1, z: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 4978785078781907030}
-  m_RootOrder: 1
+  m_Children:
+  - {fileID: 4978785078781907030}
+  - {fileID: 8691622669510500422}
+  m_Father: {fileID: 1567488188810661924}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5789419134352416845
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1379377831831995235}
+  m_Layer: 0
+  m_Name: Tile_x(10)_z(11)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1379377831831995235
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5789419134352416845}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4804872217304578302}
+  - {fileID: 3444475148769139416}
+  m_Father: {fileID: 1567488188900932962}
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &5797406224076243594
 GameObject:
@@ -32200,9 +32476,8 @@ GameObject:
   - component: {fileID: 6086844777526454972}
   - component: {fileID: 4395886522301150697}
   - component: {fileID: 8704686113435903561}
-  - component: {fileID: 270362623665055738}
   m_Layer: 0
-  m_Name: Tile_x(6)_z(13)
+  m_Name: pipe_X_LOD0
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -32221,9 +32496,8 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2950059966397817233}
-  - {fileID: 4102981382755705216}
-  m_Father: {fileID: 1567488187209773589}
-  m_RootOrder: 6
+  m_Father: {fileID: 3579426480509295461}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &3998992389094771973
 MeshFilter:
@@ -32307,7 +32581,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59a25a69e624bd24ca2d80c531be02f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _innerObjs: []
+  shrinkRate: 0.1
 --- !u!114 &8704686113435903561
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -32330,19 +32604,6 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
---- !u!65 &270362623665055738
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6471213863349738123}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 1, y: 0.953548, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &6860778302990589393
 GameObject:
   m_ObjectHideFlags: 0
@@ -32366,12 +32627,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6860778302990589393}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -10, y: -1, z: 13}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 4649993659239318855}
+  m_Father: {fileID: 8523437079741894935}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &7033436545800247799
@@ -32471,9 +32732,8 @@ GameObject:
   - component: {fileID: 400616611618970388}
   - component: {fileID: 6429976380433628548}
   - component: {fileID: 3035553322737335810}
-  - component: {fileID: 8804436388757842546}
   m_Layer: 0
-  m_Name: Tile_x(10)_z(1)
+  m_Name: pipe_X_LOD0
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -32492,9 +32752,8 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 3329050599317942731}
-  - {fileID: 7074400997766045757}
-  m_Father: {fileID: 1567488188810661924}
-  m_RootOrder: 9
+  m_Father: {fileID: 8872323832016394516}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &246269990877943484
 MeshFilter:
@@ -32578,7 +32837,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59a25a69e624bd24ca2d80c531be02f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _innerObjs: []
+  shrinkRate: 0.1
 --- !u!114 &3035553322737335810
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -32601,19 +32860,6 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
---- !u!65 &8804436388757842546
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7159142596546634160}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 1, y: 0.953548, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &7364553283530883310
 GameObject:
   m_ObjectHideFlags: 0
@@ -32628,9 +32874,8 @@ GameObject:
   - component: {fileID: 2870237591931518942}
   - component: {fileID: 3653106267519665104}
   - component: {fileID: 1447805371555666947}
-  - component: {fileID: 7983499699868971774}
   m_Layer: 0
-  m_Name: Tile_x(10)_z(5)
+  m_Name: pipe_X_LOD0
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -32649,9 +32894,8 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 222631265547141073}
-  - {fileID: 1613727430099219279}
-  m_Father: {fileID: 1567488188503610875}
-  m_RootOrder: 10
+  m_Father: {fileID: 9110935221043754606}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &688128488680854553
 MeshFilter:
@@ -32735,7 +32979,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59a25a69e624bd24ca2d80c531be02f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _innerObjs: []
+  shrinkRate: 0.1
 --- !u!114 &1447805371555666947
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -32758,19 +33002,39 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
---- !u!65 &7983499699868971774
-BoxCollider:
+--- !u!1 &7406635416536183537
+GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7364553283530883310}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 1, y: 0.953548, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8087554271394926862}
+  m_Layer: 0
+  m_Name: Tile_x(6)_z(7)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8087554271394926862
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7406635416536183537}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5284973921428782978}
+  - {fileID: 4586240119026483438}
+  m_Father: {fileID: 1567488188332870795}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &7555034269383670599
 GameObject:
   m_ObjectHideFlags: 0
@@ -32868,9 +33132,8 @@ GameObject:
   - component: {fileID: 148637225026670731}
   - component: {fileID: 6963688666892562721}
   - component: {fileID: 477319181103683092}
-  - component: {fileID: 7045775955920665835}
   m_Layer: 0
-  m_Name: Tile_x(6)_z(9)
+  m_Name: pipe_X_LOD0
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -32889,9 +33152,8 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 8257720237629846143}
-  - {fileID: 1529594175050605339}
-  m_Father: {fileID: 1567488188570961927}
-  m_RootOrder: 6
+  m_Father: {fileID: 3547579488268943688}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &6029948321576364420
 MeshFilter:
@@ -32975,7 +33237,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59a25a69e624bd24ca2d80c531be02f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _innerObjs: []
+  shrinkRate: 0.1
 --- !u!114 &477319181103683092
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -32998,19 +33260,39 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
---- !u!65 &7045775955920665835
-BoxCollider:
+--- !u!1 &8026569956272726483
+GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7855792759284073713}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 1, y: 0.953548, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3810267629735825826}
+  m_Layer: 0
+  m_Name: Tile_x(6)_z(5)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3810267629735825826
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8026569956272726483}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3421753788498467197}
+  - {fileID: 6183547513458952089}
+  m_Father: {fileID: 1567488188503610875}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &8534223004043786876
 GameObject:
   m_ObjectHideFlags: 0
@@ -33025,9 +33307,8 @@ GameObject:
   - component: {fileID: 3315002957870948767}
   - component: {fileID: 7352544468881908758}
   - component: {fileID: 743212860999380068}
-  - component: {fileID: 5667571838288334429}
   m_Layer: 0
-  m_Name: Tile_x(6)_z(5)
+  m_Name: pipe_X_LOD0
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -33046,9 +33327,8 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 546207854123562044}
-  - {fileID: 6183547513458952089}
-  m_Father: {fileID: 1567488188503610875}
-  m_RootOrder: 7
+  m_Father: {fileID: 3810267629735825826}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &836680594863987524
 MeshFilter:
@@ -33132,7 +33412,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59a25a69e624bd24ca2d80c531be02f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _innerObjs: []
+  shrinkRate: 0.1
 --- !u!114 &743212860999380068
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -33155,19 +33435,6 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
---- !u!65 &5667571838288334429
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8534223004043786876}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 1, y: 0.953548, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &8584382502838863262
 GameObject:
   m_ObjectHideFlags: 0
@@ -33274,12 +33541,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8645628687953197603}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -6, y: -1, z: 7}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 5284973921428782978}
+  m_Father: {fileID: 8087554271394926862}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &8726307521681585943
@@ -33388,12 +33655,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8767402694489731955}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -10, y: -1, z: 11}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 4804872217304578302}
+  m_Father: {fileID: 1379377831831995235}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &8943155822548685200
@@ -33410,9 +33677,8 @@ GameObject:
   - component: {fileID: 3629797910432895522}
   - component: {fileID: 325652295669576200}
   - component: {fileID: 6103407271265120229}
-  - component: {fileID: 8717212174910680656}
   m_Layer: 0
-  m_Name: Tile_x(10)_z(11)
+  m_Name: pipe_X_LOD0
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -33431,9 +33697,8 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 7280861269829419004}
-  - {fileID: 3444475148769139416}
-  m_Father: {fileID: 1567488188900932962}
-  m_RootOrder: 10
+  m_Father: {fileID: 1379377831831995235}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &1787975309753769737
 MeshFilter:
@@ -33517,7 +33782,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59a25a69e624bd24ca2d80c531be02f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _innerObjs: []
+  shrinkRate: 0.1
 --- !u!114 &6103407271265120229
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -33540,19 +33805,6 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
---- !u!65 &8717212174910680656
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8943155822548685200}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 1, y: 0.953548, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &9066999922777632647
 GameObject:
   m_ObjectHideFlags: 0
@@ -33659,12 +33911,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 9136037526189028527}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -6, y: -1, z: 11}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1273395938993616616}
+  m_Father: {fileID: 8251430844763580979}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &9141239455273261488

--- a/Assets/Develop/KMS/Prefabs/MapPrefabs/IceMap.prefab
+++ b/Assets/Develop/KMS/Prefabs/MapPrefabs/IceMap.prefab
@@ -23,79 +23,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7142995572822328}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -6, y: -1, z: 13}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 3579426480509295461}
+  m_Father: {fileID: 5915593302059509969}
   m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &90297896690709902
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3579426480509295461}
-  m_Layer: 0
-  m_Name: Tile_x(6)_z(13)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &3579426480509295461
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 90297896690709902}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 5915593302059509969}
-  - {fileID: 4102981382755705216}
-  m_Father: {fileID: 1567488187209773589}
-  m_RootOrder: 6
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &224340265487962523
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8251430844763580979}
-  m_Layer: 0
-  m_Name: Tile_x(6)_z(11)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &8251430844763580979
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 224340265487962523}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1273395938993616616}
-  - {fileID: 6926803871487988217}
-  m_Father: {fileID: 1567488188900932962}
-  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &482616946720320233
 GameObject:
@@ -120,12 +54,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 482616946720320233}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -6, y: -1, z: 5}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 3810267629735825826}
+  m_Father: {fileID: 3421753788498467197}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &894250392368678465
@@ -182,46 +116,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 960306928633623989}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -10, y: -1, z: 3}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1897303266576198582}
+  m_Father: {fileID: 8892531631797268839}
   m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &964296557568495287
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8523437079741894935}
-  m_Layer: 0
-  m_Name: Tile_x(10)_z(13)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &8523437079741894935
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 964296557568495287}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 4649993659239318855}
-  - {fileID: 5101680558904477458}
-  m_Father: {fileID: 1567488187209773589}
-  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1024059423751469859
 GameObject:
@@ -237,8 +138,9 @@ GameObject:
   - component: {fileID: 6708596083029678293}
   - component: {fileID: 4898531213166309430}
   - component: {fileID: 4737047836247342650}
+  - component: {fileID: 4317117753639961468}
   m_Layer: 0
-  m_Name: pipe_X_LOD0
+  m_Name: Tile_x(10)_z(3)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -257,8 +159,9 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 6701753571202102057}
-  m_Father: {fileID: 1897303266576198582}
-  m_RootOrder: 0
+  - {fileID: 3879969931744704031}
+  m_Father: {fileID: 1567488187523748374}
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &3800495337848546824
 MeshFilter:
@@ -342,7 +245,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59a25a69e624bd24ca2d80c531be02f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  shrinkRate: 0.1
+  _innerObjs: []
 --- !u!114 &4737047836247342650
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -365,6 +268,19 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
+--- !u!65 &4317117753639961468
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1024059423751469859}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 0.953548, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &1137968714718580854
 GameObject:
   m_ObjectHideFlags: 0
@@ -388,12 +304,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1137968714718580854}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -10, y: -1, z: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 8872323832016394516}
+  m_Father: {fileID: 4487545347565076754}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1390314533824695887
@@ -410,8 +326,9 @@ GameObject:
   - component: {fileID: 4791618920059969617}
   - component: {fileID: 736416223019761346}
   - component: {fileID: 804578433319035726}
+  - component: {fileID: 2219583650071131262}
   m_Layer: 0
-  m_Name: pipe_X_LOD0
+  m_Name: Tile_x(6)_z(1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -430,8 +347,9 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 3990553086189911762}
-  m_Father: {fileID: 2852209720836286954}
-  m_RootOrder: 0
+  - {fileID: 2006379573018671537}
+  m_Father: {fileID: 1567488188810661924}
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &5283053487624458036
 MeshFilter:
@@ -499,7 +417,7 @@ MonoBehaviour:
   explosionForce: 30
   explosionRadius: 5
   fragmentPrefab: {fileID: 7583408258262586530, guid: a988a83306ff7bc4e9fdb0a1f73ffd1d, type: 3}
-  parentContainer: {fileID: 8691622669510500422}
+  parentContainer: {fileID: 2006379573018671537}
   itemPrefabs: []
   itemSpawnChance: 0
   isContinue: 0
@@ -515,7 +433,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59a25a69e624bd24ca2d80c531be02f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  shrinkRate: 0.1
+  _innerObjs: []
 --- !u!114 &804578433319035726
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -538,6 +456,19 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
+--- !u!65 &2219583650071131262
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1390314533824695887}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 0.953548, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &1442785199544711174
 GameObject:
   m_ObjectHideFlags: 0
@@ -561,12 +492,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1442785199544711174}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -10, y: -1, z: 9}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 3502281692732303027}
+  m_Father: {fileID: 2281170754613537231}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1503386104060404580
@@ -592,12 +523,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1503386104060404580}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -6, y: -1, z: 9}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 3547579488268943688}
+  m_Father: {fileID: 7144287875862034197}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1567488187007431952
@@ -2645,10 +2576,10 @@ Transform:
   - {fileID: 1567488187408444141}
   - {fileID: 1567488187497291350}
   - {fileID: 1567488188643952007}
-  - {fileID: 3579426480509295461}
+  - {fileID: 5915593302059509969}
   - {fileID: 1567488188713901149}
   - {fileID: 8518042857321493399}
-  - {fileID: 8523437079741894935}
+  - {fileID: 4649993659239318855}
   - {fileID: 1567488188984977859}
   - {fileID: 1567488187239285923}
   - {fileID: 1567488187364665048}
@@ -7708,12 +7639,12 @@ Transform:
   - {fileID: 1567488188962112030}
   - {fileID: 1567488187454287112}
   - {fileID: 1567488188858855830}
-  - {fileID: 8771683364522783251}
+  - {fileID: 3164081151991609743}
   - {fileID: 1567488187435804922}
   - {fileID: 9104588635370025777}
   - {fileID: 1567488188126283702}
   - {fileID: 8205159744822741599}
-  - {fileID: 1897303266576198582}
+  - {fileID: 8892531631797268839}
   - {fileID: 1567488188182003503}
   - {fileID: 1567488188766198629}
   - {fileID: 1567488187775815215}
@@ -18111,11 +18042,11 @@ Transform:
   - {fileID: 1567488188525708013}
   - {fileID: 1567488187976739552}
   - {fileID: 1567488188248664878}
-  - {fileID: 8087554271394926862}
+  - {fileID: 5284973921428782978}
   - {fileID: 1567488188180807333}
   - {fileID: 4551534472062559587}
   - {fileID: 1567488187822679423}
-  - {fileID: 4993323737189854766}
+  - {fileID: 6636314211036263022}
   - {fileID: 1567488187771327213}
   - {fileID: 1567488187824951315}
   - {fileID: 1567488188882869421}
@@ -21396,10 +21327,10 @@ Transform:
   - {fileID: 1567488188074547803}
   - {fileID: 1567488188770295202}
   - {fileID: 1567488188382936881}
-  - {fileID: 3810267629735825826}
+  - {fileID: 3421753788498467197}
   - {fileID: 1567488189055560489}
   - {fileID: 6801656291037658990}
-  - {fileID: 9110935221043754606}
+  - {fileID: 4655418111188409184}
   - {fileID: 1567488187962867894}
   - {fileID: 1567488187777097678}
   - {fileID: 1567488188731258869}
@@ -22105,12 +22036,12 @@ Transform:
   - {fileID: 1567488188911626303}
   - {fileID: 1567488188489392809}
   - {fileID: 1567488187413795453}
-  - {fileID: 3547579488268943688}
+  - {fileID: 7144287875862034197}
   - {fileID: 1567488188798260698}
   - {fileID: 4405509430904419869}
   - {fileID: 1567488188991366145}
   - {fileID: 4875613094474180287}
-  - {fileID: 3502281692732303027}
+  - {fileID: 2281170754613537231}
   - {fileID: 1567488187730113915}
   - {fileID: 1567488188488679969}
   - {fileID: 1567488188118797873}
@@ -26726,11 +26657,11 @@ Transform:
   - {fileID: 1567488188478173603}
   - {fileID: 1567488187877859574}
   - {fileID: 1567488188766784420}
-  - {fileID: 2852209720836286954}
+  - {fileID: 4978785078781907030}
   - {fileID: 1567488187191303727}
   - {fileID: 1567488188398353427}
   - {fileID: 22312504237556946}
-  - {fileID: 8872323832016394516}
+  - {fileID: 4487545347565076754}
   - {fileID: 1567488188528283715}
   - {fileID: 1567488188787185957}
   - {fileID: 1567488187118084581}
@@ -27818,12 +27749,12 @@ Transform:
   - {fileID: 1567488188729249030}
   - {fileID: 1567488188223686941}
   - {fileID: 1567488187438542291}
-  - {fileID: 8251430844763580979}
+  - {fileID: 1273395938993616616}
   - {fileID: 1567488188123445248}
   - {fileID: 1567488187925985162}
   - {fileID: 3336523899463551914}
   - {fileID: 1567488187393259033}
-  - {fileID: 1379377831831995235}
+  - {fileID: 4804872217304578302}
   - {fileID: 1567488187265931960}
   - {fileID: 1567488187478243760}
   - {fileID: 1567488187894792351}
@@ -30428,70 +30359,6 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!1 &1646686300559134861
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3547579488268943688}
-  m_Layer: 0
-  m_Name: Tile_x(6)_z(9)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &3547579488268943688
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1646686300559134861}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 7144287875862034197}
-  - {fileID: 1529594175050605339}
-  m_Father: {fileID: 1567488188570961927}
-  m_RootOrder: 6
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2162410545247695801
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8691622669510500422}
-  m_Layer: 0
-  m_Name: FragmentContainer
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &8691622669510500422
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2162410545247695801}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2852209720836286954}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2364142450599541351
 GameObject:
   m_ObjectHideFlags: 0
@@ -30575,72 +30442,6 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!1 &2701330782019854148
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1897303266576198582}
-  m_Layer: 0
-  m_Name: Tile_x(10)_z(3)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1897303266576198582
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2701330782019854148}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 8892531631797268839}
-  - {fileID: 3879969931744704031}
-  m_Father: {fileID: 1567488187523748374}
-  m_RootOrder: 10
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2702686288484436368
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 9110935221043754606}
-  m_Layer: 0
-  m_Name: Tile_x(10)_z(5)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &9110935221043754606
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2702686288484436368}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 4655418111188409184}
-  - {fileID: 1613727430099219279}
-  m_Father: {fileID: 1567488188503610875}
-  m_RootOrder: 10
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2771298537655461143
 GameObject:
   m_ObjectHideFlags: 0
@@ -30655,8 +30456,9 @@ GameObject:
   - component: {fileID: 6540724125610125222}
   - component: {fileID: 8840435227386660049}
   - component: {fileID: 6629820335149591238}
+  - component: {fileID: 7750977768225554567}
   m_Layer: 0
-  m_Name: pipe_X_LOD0
+  m_Name: Tile_x(10)_z(7)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -30675,8 +30477,9 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 6001791638012703623}
-  m_Father: {fileID: 4993323737189854766}
-  m_RootOrder: 0
+  - {fileID: 2633014539333715425}
+  m_Father: {fileID: 1567488188332870795}
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &3838505043354614685
 MeshFilter:
@@ -30760,7 +30563,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59a25a69e624bd24ca2d80c531be02f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  shrinkRate: 0.1
+  _innerObjs: []
 --- !u!114 &6629820335149591238
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -30783,6 +30586,19 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
+--- !u!65 &7750977768225554567
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2771298537655461143}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 0.953548, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &2909088273934608759
 GameObject:
   m_ObjectHideFlags: 0
@@ -30889,12 +30705,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2953459837729298603}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -10, y: -1, z: 7}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 4993323737189854766}
+  m_Father: {fileID: 6636314211036263022}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &3057752347346393809
@@ -31063,138 +30879,6 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!1 &3478084909563221976
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 4993323737189854766}
-  m_Layer: 0
-  m_Name: Tile_x(10)_z(7)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &4993323737189854766
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3478084909563221976}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 6636314211036263022}
-  - {fileID: 2633014539333715425}
-  m_Father: {fileID: 1567488188332870795}
-  m_RootOrder: 10
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &3578708194620930747
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8872323832016394516}
-  m_Layer: 0
-  m_Name: Tile_x(10)_z(1)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &8872323832016394516
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3578708194620930747}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 4487545347565076754}
-  - {fileID: 7074400997766045757}
-  m_Father: {fileID: 1567488188810661924}
-  m_RootOrder: 9
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &3668551226333700328
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8771683364522783251}
-  m_Layer: 0
-  m_Name: Tile_x(6)_z(3)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &8771683364522783251
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3668551226333700328}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 3164081151991609743}
-  - {fileID: 4080778824590815214}
-  m_Father: {fileID: 1567488187523748374}
-  m_RootOrder: 5
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &3704295909494163657
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3502281692732303027}
-  m_Layer: 0
-  m_Name: Tile_x(10)_z(9)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &3502281692732303027
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3704295909494163657}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 2281170754613537231}
-  - {fileID: 5003108064067413627}
-  m_Father: {fileID: 1567488188570961927}
-  m_RootOrder: 11
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &3742220107718526250
 GameObject:
   m_ObjectHideFlags: 0
@@ -31209,8 +30893,9 @@ GameObject:
   - component: {fileID: 1344404815008971683}
   - component: {fileID: 2294532956304431377}
   - component: {fileID: 5315095390479977376}
+  - component: {fileID: 8777813085240412355}
   m_Layer: 0
-  m_Name: pipe_X_LOD0
+  m_Name: Tile_x(6)_z(7)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -31229,8 +30914,9 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 3435243868315566918}
-  m_Father: {fileID: 8087554271394926862}
-  m_RootOrder: 0
+  - {fileID: 4586240119026483438}
+  m_Father: {fileID: 1567488188332870795}
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &1916678605360133413
 MeshFilter:
@@ -31314,7 +31000,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59a25a69e624bd24ca2d80c531be02f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  shrinkRate: 0.1
+  _innerObjs: []
 --- !u!114 &5315095390479977376
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -31337,6 +31023,19 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
+--- !u!65 &8777813085240412355
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3742220107718526250}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 0.953548, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &3989335685818720969
 GameObject:
   m_ObjectHideFlags: 0
@@ -31351,8 +31050,9 @@ GameObject:
   - component: {fileID: 2684787228258900918}
   - component: {fileID: 8963270498179820006}
   - component: {fileID: 7130333748135989767}
+  - component: {fileID: 6129329582037150433}
   m_Layer: 0
-  m_Name: pipe_X_LOD0
+  m_Name: Tile_x(10)_z(9)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -31371,8 +31071,9 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 501229121830888392}
-  m_Father: {fileID: 3502281692732303027}
-  m_RootOrder: 0
+  - {fileID: 5003108064067413627}
+  m_Father: {fileID: 1567488188570961927}
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &4940067658562093806
 MeshFilter:
@@ -31456,7 +31157,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59a25a69e624bd24ca2d80c531be02f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  shrinkRate: 0.1
+  _innerObjs: []
 --- !u!114 &7130333748135989767
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -31479,6 +31180,19 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
+--- !u!65 &6129329582037150433
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3989335685818720969}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 0.953548, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &4012319597526903859
 GameObject:
   m_ObjectHideFlags: 0
@@ -31576,8 +31290,9 @@ GameObject:
   - component: {fileID: 5928543370093572941}
   - component: {fileID: 5694700581579388051}
   - component: {fileID: 609825458809976274}
+  - component: {fileID: 8686494004593973209}
   m_Layer: 0
-  m_Name: pipe_X_LOD0
+  m_Name: Tile_x(10)_z(13)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -31596,8 +31311,9 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 5849852698455250300}
-  m_Father: {fileID: 8523437079741894935}
-  m_RootOrder: 0
+  - {fileID: 5101680558904477458}
+  m_Father: {fileID: 1567488187209773589}
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &4683542501067419243
 MeshFilter:
@@ -31681,7 +31397,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59a25a69e624bd24ca2d80c531be02f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  shrinkRate: 0.1
+  _innerObjs: []
 --- !u!114 &609825458809976274
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -31704,6 +31420,19 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
+--- !u!65 &8686494004593973209
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4648439607111314511}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 0.953548, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &4696500518300077999
 GameObject:
   m_ObjectHideFlags: 0
@@ -31727,12 +31456,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4696500518300077999}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -6, y: -1, z: 3}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 8771683364522783251}
+  m_Father: {fileID: 3164081151991609743}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &4807914589925829446
@@ -31846,8 +31575,9 @@ GameObject:
   - component: {fileID: 3274761612843986421}
   - component: {fileID: 6845525786612196162}
   - component: {fileID: 3770701011900556013}
+  - component: {fileID: 3419667109833754845}
   m_Layer: 0
-  m_Name: pipe_X_LOD0
+  m_Name: Tile_x(6)_z(3)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -31866,8 +31596,9 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4601567130518626160}
-  m_Father: {fileID: 8771683364522783251}
-  m_RootOrder: 0
+  - {fileID: 4080778824590815214}
+  m_Father: {fileID: 1567488187523748374}
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &2644920357513429559
 MeshFilter:
@@ -31951,7 +31682,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59a25a69e624bd24ca2d80c531be02f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  shrinkRate: 0.1
+  _innerObjs: []
 --- !u!114 &3770701011900556013
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -31974,6 +31705,19 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
+--- !u!65 &3419667109833754845
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5222915050822273686}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 0.953548, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &5503825589449008385
 GameObject:
   m_ObjectHideFlags: 0
@@ -31997,12 +31741,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5503825589449008385}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -10, y: -1, z: 5}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 9110935221043754606}
+  m_Father: {fileID: 4655418111188409184}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &5584962602209813255
@@ -32019,8 +31763,9 @@ GameObject:
   - component: {fileID: 59932910338858441}
   - component: {fileID: 3111238701991913444}
   - component: {fileID: 3223165044494376908}
+  - component: {fileID: 6867091215370282929}
   m_Layer: 0
-  m_Name: pipe_X_LOD0
+  m_Name: Tile_x(6)_z(11)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -32039,8 +31784,9 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4593043485488699891}
-  m_Father: {fileID: 8251430844763580979}
-  m_RootOrder: 0
+  - {fileID: 6926803871487988217}
+  m_Father: {fileID: 1567488188900932962}
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &6435352105432244241
 MeshFilter:
@@ -32124,7 +31870,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59a25a69e624bd24ca2d80c531be02f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  shrinkRate: 0.1
+  _innerObjs: []
 --- !u!114 &3223165044494376908
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -32147,7 +31893,20 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
---- !u!1 &5706044351745849943
+--- !u!65 &6867091215370282929
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5584962602209813255}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 0.953548, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &5751103521344689457
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -32155,63 +31914,28 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 2852209720836286954}
+  - component: {fileID: 2006379573018671537}
   m_Layer: 0
-  m_Name: Tile_x(6)_z(1)
+  m_Name: FragmentContainer
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &2852209720836286954
+--- !u!4 &2006379573018671537
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5706044351745849943}
+  m_GameObject: {fileID: 5751103521344689457}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: -6, y: -1, z: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 4978785078781907030}
-  - {fileID: 8691622669510500422}
-  m_Father: {fileID: 1567488188810661924}
-  m_RootOrder: 5
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &5789419134352416845
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1379377831831995235}
-  m_Layer: 0
-  m_Name: Tile_x(10)_z(11)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1379377831831995235
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5789419134352416845}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 4804872217304578302}
-  - {fileID: 3444475148769139416}
-  m_Father: {fileID: 1567488188900932962}
-  m_RootOrder: 10
+  m_Children: []
+  m_Father: {fileID: 4978785078781907030}
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &5797406224076243594
 GameObject:
@@ -32476,8 +32200,9 @@ GameObject:
   - component: {fileID: 6086844777526454972}
   - component: {fileID: 4395886522301150697}
   - component: {fileID: 8704686113435903561}
+  - component: {fileID: 270362623665055738}
   m_Layer: 0
-  m_Name: pipe_X_LOD0
+  m_Name: Tile_x(6)_z(13)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -32496,8 +32221,9 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2950059966397817233}
-  m_Father: {fileID: 3579426480509295461}
-  m_RootOrder: 0
+  - {fileID: 4102981382755705216}
+  m_Father: {fileID: 1567488187209773589}
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &3998992389094771973
 MeshFilter:
@@ -32581,7 +32307,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59a25a69e624bd24ca2d80c531be02f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  shrinkRate: 0.1
+  _innerObjs: []
 --- !u!114 &8704686113435903561
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -32604,6 +32330,19 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
+--- !u!65 &270362623665055738
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6471213863349738123}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 0.953548, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &6860778302990589393
 GameObject:
   m_ObjectHideFlags: 0
@@ -32627,12 +32366,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6860778302990589393}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -10, y: -1, z: 13}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 8523437079741894935}
+  m_Father: {fileID: 4649993659239318855}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &7033436545800247799
@@ -32732,8 +32471,9 @@ GameObject:
   - component: {fileID: 400616611618970388}
   - component: {fileID: 6429976380433628548}
   - component: {fileID: 3035553322737335810}
+  - component: {fileID: 8804436388757842546}
   m_Layer: 0
-  m_Name: pipe_X_LOD0
+  m_Name: Tile_x(10)_z(1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -32752,8 +32492,9 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 3329050599317942731}
-  m_Father: {fileID: 8872323832016394516}
-  m_RootOrder: 0
+  - {fileID: 7074400997766045757}
+  m_Father: {fileID: 1567488188810661924}
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &246269990877943484
 MeshFilter:
@@ -32837,7 +32578,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59a25a69e624bd24ca2d80c531be02f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  shrinkRate: 0.1
+  _innerObjs: []
 --- !u!114 &3035553322737335810
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -32860,6 +32601,19 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
+--- !u!65 &8804436388757842546
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7159142596546634160}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 0.953548, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &7364553283530883310
 GameObject:
   m_ObjectHideFlags: 0
@@ -32874,8 +32628,9 @@ GameObject:
   - component: {fileID: 2870237591931518942}
   - component: {fileID: 3653106267519665104}
   - component: {fileID: 1447805371555666947}
+  - component: {fileID: 7983499699868971774}
   m_Layer: 0
-  m_Name: pipe_X_LOD0
+  m_Name: Tile_x(10)_z(5)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -32894,8 +32649,9 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 222631265547141073}
-  m_Father: {fileID: 9110935221043754606}
-  m_RootOrder: 0
+  - {fileID: 1613727430099219279}
+  m_Father: {fileID: 1567488188503610875}
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &688128488680854553
 MeshFilter:
@@ -32979,7 +32735,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59a25a69e624bd24ca2d80c531be02f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  shrinkRate: 0.1
+  _innerObjs: []
 --- !u!114 &1447805371555666947
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -33002,39 +32758,19 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
---- !u!1 &7406635416536183537
-GameObject:
+--- !u!65 &7983499699868971774
+BoxCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8087554271394926862}
-  m_Layer: 0
-  m_Name: Tile_x(6)_z(7)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &8087554271394926862
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7406635416536183537}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 5284973921428782978}
-  - {fileID: 4586240119026483438}
-  m_Father: {fileID: 1567488188332870795}
-  m_RootOrder: 6
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_GameObject: {fileID: 7364553283530883310}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 0.953548, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &7555034269383670599
 GameObject:
   m_ObjectHideFlags: 0
@@ -33132,8 +32868,9 @@ GameObject:
   - component: {fileID: 148637225026670731}
   - component: {fileID: 6963688666892562721}
   - component: {fileID: 477319181103683092}
+  - component: {fileID: 7045775955920665835}
   m_Layer: 0
-  m_Name: pipe_X_LOD0
+  m_Name: Tile_x(6)_z(9)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -33152,8 +32889,9 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 8257720237629846143}
-  m_Father: {fileID: 3547579488268943688}
-  m_RootOrder: 0
+  - {fileID: 1529594175050605339}
+  m_Father: {fileID: 1567488188570961927}
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &6029948321576364420
 MeshFilter:
@@ -33237,7 +32975,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59a25a69e624bd24ca2d80c531be02f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  shrinkRate: 0.1
+  _innerObjs: []
 --- !u!114 &477319181103683092
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -33260,39 +32998,19 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
---- !u!1 &8026569956272726483
-GameObject:
+--- !u!65 &7045775955920665835
+BoxCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3810267629735825826}
-  m_Layer: 0
-  m_Name: Tile_x(6)_z(5)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &3810267629735825826
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8026569956272726483}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 3421753788498467197}
-  - {fileID: 6183547513458952089}
-  m_Father: {fileID: 1567488188503610875}
-  m_RootOrder: 7
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_GameObject: {fileID: 7855792759284073713}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 0.953548, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &8534223004043786876
 GameObject:
   m_ObjectHideFlags: 0
@@ -33307,8 +33025,9 @@ GameObject:
   - component: {fileID: 3315002957870948767}
   - component: {fileID: 7352544468881908758}
   - component: {fileID: 743212860999380068}
+  - component: {fileID: 5667571838288334429}
   m_Layer: 0
-  m_Name: pipe_X_LOD0
+  m_Name: Tile_x(6)_z(5)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -33327,8 +33046,9 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 546207854123562044}
-  m_Father: {fileID: 3810267629735825826}
-  m_RootOrder: 0
+  - {fileID: 6183547513458952089}
+  m_Father: {fileID: 1567488188503610875}
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &836680594863987524
 MeshFilter:
@@ -33412,7 +33132,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59a25a69e624bd24ca2d80c531be02f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  shrinkRate: 0.1
+  _innerObjs: []
 --- !u!114 &743212860999380068
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -33435,6 +33155,19 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
+--- !u!65 &5667571838288334429
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8534223004043786876}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 0.953548, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &8584382502838863262
 GameObject:
   m_ObjectHideFlags: 0
@@ -33541,12 +33274,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8645628687953197603}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -6, y: -1, z: 7}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 8087554271394926862}
+  m_Father: {fileID: 5284973921428782978}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &8726307521681585943
@@ -33655,12 +33388,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8767402694489731955}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -10, y: -1, z: 11}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1379377831831995235}
+  m_Father: {fileID: 4804872217304578302}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &8943155822548685200
@@ -33677,8 +33410,9 @@ GameObject:
   - component: {fileID: 3629797910432895522}
   - component: {fileID: 325652295669576200}
   - component: {fileID: 6103407271265120229}
+  - component: {fileID: 8717212174910680656}
   m_Layer: 0
-  m_Name: pipe_X_LOD0
+  m_Name: Tile_x(10)_z(11)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -33697,8 +33431,9 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 7280861269829419004}
-  m_Father: {fileID: 1379377831831995235}
-  m_RootOrder: 0
+  - {fileID: 3444475148769139416}
+  m_Father: {fileID: 1567488188900932962}
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &1787975309753769737
 MeshFilter:
@@ -33782,7 +33517,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59a25a69e624bd24ca2d80c531be02f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  shrinkRate: 0.1
+  _innerObjs: []
 --- !u!114 &6103407271265120229
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -33805,6 +33540,19 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
+--- !u!65 &8717212174910680656
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8943155822548685200}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 0.953548, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &9066999922777632647
 GameObject:
   m_ObjectHideFlags: 0
@@ -33911,12 +33659,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 9136037526189028527}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -6, y: -1, z: 11}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 8251430844763580979}
+  m_Father: {fileID: 1273395938993616616}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &9141239455273261488

--- a/Assets/Develop/KMS/Prefabs/ObstaclePrefabs/MovingBox.prefab
+++ b/Assets/Develop/KMS/Prefabs/ObstaclePrefabs/MovingBox.prefab
@@ -23,7 +23,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2417847850571316751}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0

--- a/Assets/Develop/KMS/Prefabs/ObstaclePrefabs/MovingBox.prefab
+++ b/Assets/Develop/KMS/Prefabs/ObstaclePrefabs/MovingBox.prefab
@@ -23,7 +23,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2417847850571316751}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0

--- a/Assets/Develop/KMS/Prefabs/ObstaclePrefabs/OB_M_Factroy.prefab
+++ b/Assets/Develop/KMS/Prefabs/ObstaclePrefabs/OB_M_Factroy.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &4833430599522112391
+--- !u!1 &463143486899927961
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,9 +8,9 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 4834844931313232383}
-  - component: {fileID: 4855947382739592057}
-  - component: {fileID: 4846600715079153849}
+  - component: {fileID: 461180054545990113}
+  - component: {fileID: 440626411760126823}
+  - component: {fileID: 449291948885414055}
   m_Layer: 0
   m_Name: valve_LOD0
   m_TagString: Untagged
@@ -18,36 +18,36 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &4834844931313232383
+--- !u!4 &461180054545990113
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4833430599522112391}
+  m_GameObject: {fileID: 463143486899927961}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0.25, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 5962224160771652036}
+  m_Father: {fileID: 1711563852081779162}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &4855947382739592057
+--- !u!33 &440626411760126823
 MeshFilter:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4833430599522112391}
+  m_GameObject: {fileID: 463143486899927961}
   m_Mesh: {fileID: 4300000, guid: 620dcd72b52a8e245b7b1d9e87c277ab, type: 3}
---- !u!23 &4846600715079153849
+--- !u!23 &449291948885414055
 MeshRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4833430599522112391}
+  m_GameObject: {fileID: 463143486899927961}
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
@@ -83,7 +83,7 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!1 &5548551650412257618
+--- !u!1 &612150202866501964
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -91,7 +91,7 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 6123422836511505297}
+  - component: {fileID: 1262245575323554703}
   m_Layer: 0
   m_Name: FragmentContainer
   m_TagString: Untagged
@@ -99,22 +99,22 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &6123422836511505297
+--- !u!4 &1262245575323554703
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5548551650412257618}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: -0.5, z: 0}
+  m_GameObject: {fileID: 612150202866501964}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 5962224160771652036}
+  m_Father: {fileID: 2378461373845996938}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &5959556302969835724
+--- !u!1 &1714246278017546450
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -122,52 +122,50 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 5962224160771652036}
-  - component: {fileID: 5965372605075395304}
-  - component: {fileID: 5973241239073916732}
-  - component: {fileID: 4643317974028013518}
-  - component: {fileID: 6715341833984215056}
-  - component: {fileID: 1891655700398426449}
-  - component: {fileID: 1891655700398426450}
+  - component: {fileID: 1711563852081779162}
+  - component: {fileID: 1709085061370739446}
+  - component: {fileID: 1701118536468360994}
+  - component: {fileID: 364439800025982928}
+  - component: {fileID: 1751635101688750094}
+  - component: {fileID: 6862962326738772303}
   m_Layer: 0
-  m_Name: OB_M_Factroy
+  m_Name: pipe_X_LOD0
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &5962224160771652036
+--- !u!4 &1711563852081779162
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5959556302969835724}
+  m_GameObject: {fileID: 1714246278017546450}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0.5, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 4834844931313232383}
-  - {fileID: 6123422836511505297}
-  m_Father: {fileID: 0}
+  - {fileID: 461180054545990113}
+  m_Father: {fileID: 2378461373845996938}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &5965372605075395304
+--- !u!33 &1709085061370739446
 MeshFilter:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5959556302969835724}
+  m_GameObject: {fileID: 1714246278017546450}
   m_Mesh: {fileID: 4300000, guid: 5e9ac702f564ee548a68a1bc5568f906, type: 3}
---- !u!23 &5973241239073916732
+--- !u!23 &1701118536468360994
 MeshRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5959556302969835724}
+  m_GameObject: {fileID: 1714246278017546450}
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
@@ -203,13 +201,13 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!114 &4643317974028013518
+--- !u!114 &364439800025982928
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5959556302969835724}
+  m_GameObject: {fileID: 1714246278017546450}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: d7c329bd53db41442bbeba067156ffa0, type: 3}
@@ -219,30 +217,30 @@ MonoBehaviour:
   explosionForce: 30
   explosionRadius: 5
   fragmentPrefab: {fileID: 7583408258262586530, guid: a988a83306ff7bc4e9fdb0a1f73ffd1d, type: 3}
-  parentContainer: {fileID: 6123422836511505297}
+  parentContainer: {fileID: 1262245575323554703}
   itemPrefabs: []
   itemSpawnChance: 0
   isContinue: 0
---- !u!114 &6715341833984215056
+--- !u!114 &1751635101688750094
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5959556302969835724}
+  m_GameObject: {fileID: 1714246278017546450}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 59a25a69e624bd24ca2d80c531be02f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _innerObjs: []
---- !u!114 &1891655700398426449
+  shrinkRate: 0.1
+--- !u!114 &6862962326738772303
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5959556302969835724}
+  m_GameObject: {fileID: 1714246278017546450}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: aa584fbee541324448dd18d8409c7a41, type: 3}
@@ -258,16 +256,36 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
---- !u!65 &1891655700398426450
-BoxCollider:
+--- !u!1 &6496851780708342314
+GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5959556302969835724}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 1, y: 0.953548, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2378461373845996938}
+  m_Layer: 0
+  m_Name: OB_M_Factroy
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2378461373845996938
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6496851780708342314}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1711563852081779162}
+  - {fileID: 1262245575323554703}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Develop/KMS/Prefabs/ObstaclePrefabs/OB_M_Factroy.prefab
+++ b/Assets/Develop/KMS/Prefabs/ObstaclePrefabs/OB_M_Factroy.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &463143486899927961
+--- !u!1 &4833430599522112391
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,9 +8,9 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 461180054545990113}
-  - component: {fileID: 440626411760126823}
-  - component: {fileID: 449291948885414055}
+  - component: {fileID: 4834844931313232383}
+  - component: {fileID: 4855947382739592057}
+  - component: {fileID: 4846600715079153849}
   m_Layer: 0
   m_Name: valve_LOD0
   m_TagString: Untagged
@@ -18,36 +18,36 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &461180054545990113
+--- !u!4 &4834844931313232383
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 463143486899927961}
+  m_GameObject: {fileID: 4833430599522112391}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0.25, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1711563852081779162}
+  m_Father: {fileID: 5962224160771652036}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &440626411760126823
+--- !u!33 &4855947382739592057
 MeshFilter:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 463143486899927961}
+  m_GameObject: {fileID: 4833430599522112391}
   m_Mesh: {fileID: 4300000, guid: 620dcd72b52a8e245b7b1d9e87c277ab, type: 3}
---- !u!23 &449291948885414055
+--- !u!23 &4846600715079153849
 MeshRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 463143486899927961}
+  m_GameObject: {fileID: 4833430599522112391}
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
@@ -83,7 +83,7 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!1 &612150202866501964
+--- !u!1 &5548551650412257618
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -91,7 +91,7 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1262245575323554703}
+  - component: {fileID: 6123422836511505297}
   m_Layer: 0
   m_Name: FragmentContainer
   m_TagString: Untagged
@@ -99,22 +99,22 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1262245575323554703
+--- !u!4 &6123422836511505297
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 612150202866501964}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_GameObject: {fileID: 5548551650412257618}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: -0.5, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 2378461373845996938}
+  m_Father: {fileID: 5962224160771652036}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1714246278017546450
+--- !u!1 &5959556302969835724
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -122,50 +122,52 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1711563852081779162}
-  - component: {fileID: 1709085061370739446}
-  - component: {fileID: 1701118536468360994}
-  - component: {fileID: 364439800025982928}
-  - component: {fileID: 1751635101688750094}
-  - component: {fileID: 6862962326738772303}
+  - component: {fileID: 5962224160771652036}
+  - component: {fileID: 5965372605075395304}
+  - component: {fileID: 5973241239073916732}
+  - component: {fileID: 4643317974028013518}
+  - component: {fileID: 6715341833984215056}
+  - component: {fileID: 1891655700398426449}
+  - component: {fileID: 1891655700398426450}
   m_Layer: 0
-  m_Name: pipe_X_LOD0
+  m_Name: OB_M_Factroy
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1711563852081779162
+--- !u!4 &5962224160771652036
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1714246278017546450}
+  m_GameObject: {fileID: 5959556302969835724}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0.5, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 461180054545990113}
-  m_Father: {fileID: 2378461373845996938}
+  - {fileID: 4834844931313232383}
+  - {fileID: 6123422836511505297}
+  m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &1709085061370739446
+--- !u!33 &5965372605075395304
 MeshFilter:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1714246278017546450}
+  m_GameObject: {fileID: 5959556302969835724}
   m_Mesh: {fileID: 4300000, guid: 5e9ac702f564ee548a68a1bc5568f906, type: 3}
---- !u!23 &1701118536468360994
+--- !u!23 &5973241239073916732
 MeshRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1714246278017546450}
+  m_GameObject: {fileID: 5959556302969835724}
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
@@ -201,13 +203,13 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!114 &364439800025982928
+--- !u!114 &4643317974028013518
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1714246278017546450}
+  m_GameObject: {fileID: 5959556302969835724}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: d7c329bd53db41442bbeba067156ffa0, type: 3}
@@ -217,30 +219,30 @@ MonoBehaviour:
   explosionForce: 30
   explosionRadius: 5
   fragmentPrefab: {fileID: 7583408258262586530, guid: a988a83306ff7bc4e9fdb0a1f73ffd1d, type: 3}
-  parentContainer: {fileID: 1262245575323554703}
+  parentContainer: {fileID: 6123422836511505297}
   itemPrefabs: []
   itemSpawnChance: 0
   isContinue: 0
---- !u!114 &1751635101688750094
+--- !u!114 &6715341833984215056
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1714246278017546450}
+  m_GameObject: {fileID: 5959556302969835724}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 59a25a69e624bd24ca2d80c531be02f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  shrinkRate: 0.1
---- !u!114 &6862962326738772303
+  _innerObjs: []
+--- !u!114 &1891655700398426449
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1714246278017546450}
+  m_GameObject: {fileID: 5959556302969835724}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: aa584fbee541324448dd18d8409c7a41, type: 3}
@@ -256,36 +258,16 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
---- !u!1 &6496851780708342314
-GameObject:
+--- !u!65 &1891655700398426450
+BoxCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2378461373845996938}
-  m_Layer: 0
-  m_Name: OB_M_Factroy
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2378461373845996938
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6496851780708342314}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1711563852081779162}
-  - {fileID: 1262245575323554703}
-  m_Father: {fileID: 0}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_GameObject: {fileID: 5959556302969835724}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 0.953548, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Assets/Develop/KMS/Scenes/KMS_Factory07.unity
+++ b/Assets/Develop/KMS/Scenes/KMS_Factory07.unity
@@ -300,6 +300,67 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 75, y: 0, z: 0}
+--- !u!1001 &1230372620
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2513911926319218584, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: mapObject
+      value: 
+      objectReference: {fileID: 6653071582211647237}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218589, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_Name
+      value: TestScene
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
 --- !u!1 &1563450301
 GameObject:
   m_ObjectHideFlags: 0
@@ -559,3 +620,8 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7d5bd6f4f23c31e4cbf7c83bf41c2d95, type: 3}
+--- !u!1 &6653071582211647237 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7562494353727788640, guid: 7d5bd6f4f23c31e4cbf7c83bf41c2d95, type: 3}
+  m_PrefabInstance: {fileID: 6653071582211647236}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/Develop/KMS/Scenes/KMS_Factory07.unity
+++ b/Assets/Develop/KMS/Scenes/KMS_Factory07.unity
@@ -300,67 +300,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 75, y: 0, z: 0}
---- !u!1001 &1230372620
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 2513911926319218584, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: mapObject
-      value: 
-      objectReference: {fileID: 6653071582211647237}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_RootOrder
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218589, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_Name
-      value: TestScene
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
 --- !u!1 &1563450301
 GameObject:
   m_ObjectHideFlags: 0
@@ -620,8 +559,3 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7d5bd6f4f23c31e4cbf7c83bf41c2d95, type: 3}
---- !u!1 &6653071582211647237 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 7562494353727788640, guid: 7d5bd6f4f23c31e4cbf7c83bf41c2d95, type: 3}
-  m_PrefabInstance: {fileID: 6653071582211647236}
-  m_PrefabAsset: {fileID: 0}

--- a/Assets/Develop/KMS/Scenes/KMS_Forest07.unity
+++ b/Assets/Develop/KMS/Scenes/KMS_Forest07.unity
@@ -292,67 +292,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 67, y: 0, z: 0}
---- !u!1001 &829327095
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 2513911926319218584, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: mapObject
-      value: 
-      objectReference: {fileID: 1828072466778122474}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_RootOrder
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218589, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_Name
-      value: TestScene
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
 --- !u!1 &1205744317
 GameObject:
   m_ObjectHideFlags: 0
@@ -968,8 +907,3 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7884b409f2c26aa4cb440e80e1087382, type: 3}
---- !u!1 &1828072466778122474 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 7584513432828599301, guid: 7884b409f2c26aa4cb440e80e1087382, type: 3}
-  m_PrefabInstance: {fileID: 1828072466778122473}
-  m_PrefabAsset: {fileID: 0}

--- a/Assets/Develop/KMS/Scenes/KMS_Forest07.unity
+++ b/Assets/Develop/KMS/Scenes/KMS_Forest07.unity
@@ -292,6 +292,67 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 67, y: 0, z: 0}
+--- !u!1001 &829327095
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2513911926319218584, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: mapObject
+      value: 
+      objectReference: {fileID: 1828072466778122474}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218589, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_Name
+      value: TestScene
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
 --- !u!1 &1205744317
 GameObject:
   m_ObjectHideFlags: 0
@@ -907,3 +968,8 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7884b409f2c26aa4cb440e80e1087382, type: 3}
+--- !u!1 &1828072466778122474 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7584513432828599301, guid: 7884b409f2c26aa4cb440e80e1087382, type: 3}
+  m_PrefabInstance: {fileID: 1828072466778122473}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/Develop/KMS/Scenes/KMS_ICE_Scene.unity
+++ b/Assets/Develop/KMS/Scenes/KMS_ICE_Scene.unity
@@ -18615,10 +18615,6 @@ PrefabInstance:
       propertyPath: sceneViewId
       value: 106
       objectReference: {fileID: 0}
-    - target: {fileID: 435329627756748944, guid: c62be7315910d4a4f8c8b685e2862e89, type: 3}
-      propertyPath: sceneViewId
-      value: 103
-      objectReference: {fileID: 0}
     - target: {fileID: 441435024516518749, guid: c62be7315910d4a4f8c8b685e2862e89, type: 3}
       propertyPath: sceneViewId
       value: 90

--- a/Assets/Develop/KMS/Scenes/KMS_ICE_Scene.unity
+++ b/Assets/Develop/KMS/Scenes/KMS_ICE_Scene.unity
@@ -18615,6 +18615,10 @@ PrefabInstance:
       propertyPath: sceneViewId
       value: 106
       objectReference: {fileID: 0}
+    - target: {fileID: 435329627756748944, guid: c62be7315910d4a4f8c8b685e2862e89, type: 3}
+      propertyPath: sceneViewId
+      value: 103
+      objectReference: {fileID: 0}
     - target: {fileID: 441435024516518749, guid: c62be7315910d4a4f8c8b685e2862e89, type: 3}
       propertyPath: sceneViewId
       value: 90

--- a/Assets/Develop/KMS/Scenes/KMS_PirateMap.unity
+++ b/Assets/Develop/KMS/Scenes/KMS_PirateMap.unity
@@ -330,67 +330,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 5739775961978685408, guid: 1f25b795c421f9f4f9ee105bb689e070, type: 3}
   m_PrefabInstance: {fileID: 385153480}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &1262988206
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 2513911926319218584, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: mapObject
-      value: 
-      objectReference: {fileID: 7476879725236707338}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_RootOrder
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218589, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_Name
-      value: TestScene
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
 --- !u!1 &1586104662
 GameObject:
   m_ObjectHideFlags: 0
@@ -636,8 +575,3 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 276ef2f3692fc8a4dad0d615121e1e47, type: 3}
---- !u!1 &7476879725236707338 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 7476879724370542285, guid: 276ef2f3692fc8a4dad0d615121e1e47, type: 3}
-  m_PrefabInstance: {fileID: 7476879725236707337}
-  m_PrefabAsset: {fileID: 0}

--- a/Assets/Develop/KMS/Scenes/KMS_PirateMap.unity
+++ b/Assets/Develop/KMS/Scenes/KMS_PirateMap.unity
@@ -330,6 +330,67 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 5739775961978685408, guid: 1f25b795c421f9f4f9ee105bb689e070, type: 3}
   m_PrefabInstance: {fileID: 385153480}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1262988206
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2513911926319218584, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: mapObject
+      value: 
+      objectReference: {fileID: 7476879725236707338}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218589, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_Name
+      value: TestScene
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
 --- !u!1 &1586104662
 GameObject:
   m_ObjectHideFlags: 0
@@ -575,3 +636,8 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 276ef2f3692fc8a4dad0d615121e1e47, type: 3}
+--- !u!1 &7476879725236707338 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7476879724370542285, guid: 276ef2f3692fc8a4dad0d615121e1e47, type: 3}
+  m_PrefabInstance: {fileID: 7476879725236707337}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/Develop/SHW/Resources/Player.prefab
+++ b/Assets/Develop/SHW/Resources/Player.prefab
@@ -358,6 +358,19 @@ MonoBehaviour:
   m_SynchronizeRotation: 1
   m_SynchronizeScale: 0
   m_UseLocal: 1
+--- !u!114 &-6957661459768671870
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5323386283925807557}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 02208deaf0b2185498be9236bcc17018, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _cache: []
 --- !u!1001 &4416417920273089596
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -445,19 +458,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: b9554c186a77c534b8c59f664a56f4a9, type: 3}
   m_PrefabInstance: {fileID: 4416417920273089596}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &-6957661459768671870
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5323386283925807557}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 02208deaf0b2185498be9236bcc17018, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _cache: []
 --- !u!1001 &5323386284024206403
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Level/Factory07.unity
+++ b/Assets/Scenes/Level/Factory07.unity
@@ -300,67 +300,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 75, y: 0, z: 0}
---- !u!1001 &1039896829
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 2513911926319218584, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: mapObject
-      value: 
-      objectReference: {fileID: 6653071582211647237}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_RootOrder
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218589, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_Name
-      value: TestScene
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
 --- !u!1 &1563450301
 GameObject:
   m_ObjectHideFlags: 0
@@ -620,8 +559,3 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7d5bd6f4f23c31e4cbf7c83bf41c2d95, type: 3}
---- !u!1 &6653071582211647237 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 7562494353727788640, guid: 7d5bd6f4f23c31e4cbf7c83bf41c2d95, type: 3}
-  m_PrefabInstance: {fileID: 6653071582211647236}
-  m_PrefabAsset: {fileID: 0}

--- a/Assets/Scenes/Level/Factory07.unity
+++ b/Assets/Scenes/Level/Factory07.unity
@@ -300,6 +300,67 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 75, y: 0, z: 0}
+--- !u!1001 &1039896829
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2513911926319218584, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: mapObject
+      value: 
+      objectReference: {fileID: 6653071582211647237}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218589, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_Name
+      value: TestScene
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
 --- !u!1 &1563450301
 GameObject:
   m_ObjectHideFlags: 0
@@ -559,3 +620,8 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7d5bd6f4f23c31e4cbf7c83bf41c2d95, type: 3}
+--- !u!1 &6653071582211647237 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7562494353727788640, guid: 7d5bd6f4f23c31e4cbf7c83bf41c2d95, type: 3}
+  m_PrefabInstance: {fileID: 6653071582211647236}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/Scenes/Level/Forest07.unity
+++ b/Assets/Scenes/Level/Forest07.unity
@@ -208,67 +208,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 5739775961978685408, guid: 1f25b795c421f9f4f9ee105bb689e070, type: 3}
   m_PrefabInstance: {fileID: 205461397}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &545852577
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 2513911926319218584, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: mapObject
-      value: 
-      objectReference: {fileID: 1828072466778122474}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_RootOrder
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218589, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_Name
-      value: TestScene
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
 --- !u!1 &732903431
 GameObject:
   m_ObjectHideFlags: 0
@@ -968,8 +907,3 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7884b409f2c26aa4cb440e80e1087382, type: 3}
---- !u!1 &1828072466778122474 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 7584513432828599301, guid: 7884b409f2c26aa4cb440e80e1087382, type: 3}
-  m_PrefabInstance: {fileID: 1828072466778122473}
-  m_PrefabAsset: {fileID: 0}

--- a/Assets/Scenes/Level/Forest07.unity
+++ b/Assets/Scenes/Level/Forest07.unity
@@ -208,6 +208,67 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 5739775961978685408, guid: 1f25b795c421f9f4f9ee105bb689e070, type: 3}
   m_PrefabInstance: {fileID: 205461397}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &545852577
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2513911926319218584, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: mapObject
+      value: 
+      objectReference: {fileID: 1828072466778122474}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218589, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_Name
+      value: TestScene
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
 --- !u!1 &732903431
 GameObject:
   m_ObjectHideFlags: 0
@@ -907,3 +968,8 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7884b409f2c26aa4cb440e80e1087382, type: 3}
+--- !u!1 &1828072466778122474 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7584513432828599301, guid: 7884b409f2c26aa4cb440e80e1087382, type: 3}
+  m_PrefabInstance: {fileID: 1828072466778122473}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/Scenes/Level/Pirate14.unity
+++ b/Assets/Scenes/Level/Pirate14.unity
@@ -330,6 +330,67 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 5739775961978685408, guid: 1f25b795c421f9f4f9ee105bb689e070, type: 3}
   m_PrefabInstance: {fileID: 385153480}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1461448033
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2513911926319218584, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: mapObject
+      value: 
+      objectReference: {fileID: 7476879725236707338}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2513911926319218589, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
+      propertyPath: m_Name
+      value: TestScene
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
 --- !u!1 &1586104662
 GameObject:
   m_ObjectHideFlags: 0
@@ -575,3 +636,8 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 276ef2f3692fc8a4dad0d615121e1e47, type: 3}
+--- !u!1 &7476879725236707338 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7476879724370542285, guid: 276ef2f3692fc8a4dad0d615121e1e47, type: 3}
+  m_PrefabInstance: {fileID: 7476879725236707337}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/Scenes/Level/Pirate14.unity
+++ b/Assets/Scenes/Level/Pirate14.unity
@@ -330,67 +330,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 5739775961978685408, guid: 1f25b795c421f9f4f9ee105bb689e070, type: 3}
   m_PrefabInstance: {fileID: 385153480}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &1461448033
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 2513911926319218584, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: mapObject
-      value: 
-      objectReference: {fileID: 7476879725236707338}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_RootOrder
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218586, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2513911926319218589, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
-      propertyPath: m_Name
-      value: TestScene
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 8ff917981b102fe43bea7deadb6f0853, type: 3}
 --- !u!1 &1586104662
 GameObject:
   m_ObjectHideFlags: 0
@@ -636,8 +575,3 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 276ef2f3692fc8a4dad0d615121e1e47, type: 3}
---- !u!1 &7476879725236707338 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 7476879724370542285, guid: 276ef2f3692fc8a4dad0d615121e1e47, type: 3}
-  m_PrefabInstance: {fileID: 7476879725236707337}
-  m_PrefabAsset: {fileID: 0}


### PR DESCRIPTION
- 팩토리 맵의 경우 부서지는 타일과 안부서지는 타일을 반대로 생성해두었습니다.(디자인을 보려고 반대로 설치해둠.)
- Enterable프리펩 충돌체 없는 부분 수정.
- 새로 추가한 게임 씬 시작 시 스폰지역 비활성화 수정.
- 플레이어 리소스 프리펩 부분의 수정사항 배제하고 다시 신청합니다.